### PR TITLE
Add flow-base from flow-for-vscode

### DIFF
--- a/server/src/pkg/commons-node/BatchProcessedQueue.js
+++ b/server/src/pkg/commons-node/BatchProcessedQueue.js
@@ -1,0 +1,51 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export type BatchHandler<T> = (batch: Array<T>) => void;
+
+// A Queue which will process elements at intervals, only if the
+// queue contains any elements.
+export default class BatchProcessedQueue<T> {
+  _batchPeriod: number;
+  _handler: BatchHandler<T>;
+  _timeoutId: ?number;
+  _items: Array<T>;
+
+  constructor(batchPeriod: number, handler: BatchHandler<T>) {
+    this._batchPeriod = batchPeriod;
+    this._handler = handler;
+    this._timeoutId = null;
+    this._items = [];
+  }
+
+  add(item: T): void {
+    this._items.push(item);
+    if (this._timeoutId === null) {
+      this._timeoutId = setTimeout(() => {
+        this._handleBatch();
+      }, this._batchPeriod);
+    }
+  }
+
+  _handleBatch() {
+    this._timeoutId = null;
+    const batch = this._items;
+    this._items = [];
+    this._handler(batch);
+  }
+
+  dispose(): void {
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+      this._handleBatch();
+    }
+  }
+}

--- a/server/src/pkg/commons-node/CircularBuffer.js
+++ b/server/src/pkg/commons-node/CircularBuffer.js
@@ -1,0 +1,88 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export default class CircularBuffer<T> {
+  /** The maximum number of elements this CircularBuffer can hold. */
+  _capacity: number;
+  _elements: Array<T>;
+  _nextInsertIndex: number;
+
+  /** Whether this CircularBuffer has reached its capacity. */
+  _isFull: boolean;
+
+  /**
+   * Represents the state of the CircularBuffer when an Iterator for it is created. If the
+   * state of the CircularBuffer changes while it is being iterated, it will throw an exception.
+   */
+  _generation: number;
+
+  /**
+   * @param capacity is the maximum number of elements this CircularBuffer can hold. It must be an
+   *   integer greater than zero.
+   */
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity)) {
+      throw new Error(`capacity must be an integer, but was ${capacity}.`);
+    }
+    if (capacity <= 0) {
+      throw new Error(`capacity must be greater than zero, but was ${capacity}.`);
+    }
+    this._capacity = capacity;
+    this._elements = new Array(capacity);
+    this._nextInsertIndex = 0;
+    this._isFull = false;
+    this._generation = 0;
+  }
+
+  /**
+   * The maximum number of elements this CircularBuffer can hold.
+   */
+  get capacity(): number {
+    return this._capacity;
+  }
+
+  push(element: T): void {
+    ++this._generation;
+    this._elements[this._nextInsertIndex] = element;
+    const nextIndex = this._nextInsertIndex + 1;
+    this._nextInsertIndex = nextIndex % this._capacity;
+    if (this._nextInsertIndex === 0 && !this._isFull) {
+      this._isFull = true;
+    }
+  }
+
+  /**
+   * @return an `Iterator` that iterates through the last N elements added to the buffer where N
+   *   is <= `capacty`. If the buffer is modified while it is being iterated, an Error will be
+   *   thrown.
+   */
+  // $FlowIssue: t6187050
+  [Symbol.iterator](): Iterator<T> {
+    const generation = this._generation;
+    let index = this._isFull ? this._nextInsertIndex : 0;
+    let numIterations = this._isFull ? this._capacity : this._nextInsertIndex;
+
+    const next = (): {done: boolean; value: ?T} => {
+      if (numIterations === 0) {
+        return {done: true, value: undefined};
+      }
+      if (generation !== this._generation) {
+        throw new Error('CircularBuffer was modified during iteration.');
+      }
+      --numIterations;
+      const value = this._elements[index];
+      index = (index + 1) % this._capacity;
+      return {done: false, value};
+    };
+
+    return {next};
+  }
+}

--- a/server/src/pkg/commons-node/ScribeProcess.js
+++ b/server/src/pkg/commons-node/ScribeProcess.js
@@ -1,0 +1,104 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import os from 'os';
+import {asyncExecute, safeSpawn} from './process';
+
+const DEFAULT_JOIN_TIMEOUT = 5000;
+let SCRIBE_CAT_COMMAND = 'scribe_cat';
+
+/**
+ * A wrapper of `scribe_cat` (https://github.com/facebookarchive/scribe/blob/master/examples/scribe_cat)
+ * command. User could call `new ScribeProcess($scribeCategoryName)` to create a process and then
+ * call `scribeProcess.write($object)` to save an JSON schemaed Object into scribe category.
+ * It will also recover from `scribe_cat` failure automatically.
+ */
+export default class ScribeProcess {
+  _scribeCategory: string;
+  _childPromise: ?Promise<child_process$ChildProcess>;
+  _childProcessRunning: WeakMap<child_process$ChildProcess, boolean>;
+
+  constructor(scribeCategory: string) {
+    this._scribeCategory = scribeCategory;
+    this._childProcessRunning = new WeakMap();
+    this._getOrCreateChildProcess();
+  }
+
+  /**
+   * Check if `scribe_cat` exists in PATH.
+   */
+  static async isScribeCatOnPath(): Promise<boolean> {
+    const {exitCode} = await asyncExecute('which', [SCRIBE_CAT_COMMAND]);
+    return exitCode === 0;
+  }
+
+  /**
+   * Write a string to a Scribe category.
+   * Ensure newlines are properly escaped.
+   */
+  async write(message: string): Promise<void> {
+    const child = await this._getOrCreateChildProcess();
+    return new Promise((resolve, reject) => {
+      child.stdin.write(`${message}${os.EOL}`, resolve);
+    });
+  }
+
+  async dispose(): Promise<void> {
+    if (this._childPromise) {
+      const child = await this._childPromise;
+      if (this._childProcessRunning.get(child)) {
+        child.kill();
+      }
+    }
+  }
+
+  async join(timeout: number = DEFAULT_JOIN_TIMEOUT): Promise<void> {
+    if (this._childPromise) {
+      const child = await this._childPromise;
+      child.stdin.end();
+      return new Promise(resolve => {
+        child.on('exit', () => resolve());
+        setTimeout(resolve, timeout);
+      });
+    }
+  }
+
+  _getOrCreateChildProcess(): Promise<child_process$ChildProcess> {
+    if (this._childPromise) {
+      return this._childPromise;
+    }
+
+    this._childPromise = safeSpawn(SCRIBE_CAT_COMMAND, [this._scribeCategory])
+        .then(child => {
+          child.stdin.setDefaultEncoding('utf8');
+          this._childProcessRunning.set(child, true);
+          child.on('error', error => {
+            this._childPromise = null;
+            this._childProcessRunning.set(child, false);
+          });
+          child.on('exit', e => {
+            this._childPromise = null;
+            this._childProcessRunning.set(child, false);
+          });
+          return child;
+        });
+
+    return this._childPromise;
+  }
+}
+
+export const __test__ = {
+  setScribeCatCommand(newCommand: string): string {
+    const originalCommand = SCRIBE_CAT_COMMAND;
+    SCRIBE_CAT_COMMAND = newCommand;
+    return originalCommand;
+  },
+};

--- a/server/src/pkg/commons-node/collection.js
+++ b/server/src/pkg/commons-node/collection.js
@@ -1,0 +1,215 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export function arrayRemove<T>(array: Array<T>, element: T): void {
+  const index = array.indexOf(element);
+  if (index >= 0) {
+    array.splice(index, 1);
+  }
+}
+
+export function arrayEqual<T>(
+  array1: Array<T>,
+  array2: Array<T>,
+  equalComparator?: (a: T, b: T) => boolean,
+): boolean {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+  const equalFunction = equalComparator || ((a: T, b: T) => a === b);
+  return array1.every((item1, i) => equalFunction(item1, array2[i]));
+}
+
+/**
+ * Returns a copy of the input Array with all `null` and `undefined` values filtered out.
+ * Allows Flow to typecheck the common `filter(x => x != null)` pattern.
+ */
+export function arrayCompact<T>(array: Array<?T>): Array<T> {
+  const result = [];
+  for (const elem of array) {
+    if (elem != null) {
+      result.push(elem);
+    }
+  }
+  return result;
+}
+
+/**
+ * Merges a given arguments of maps into one Map, with the latest maps
+ * overriding the values of the prior maps.
+ */
+export function mapUnion<T, X>(...maps: Array<Map<T, X>>): Map<T, X> {
+  const unionMap = new Map();
+  for (const map of maps) {
+    for (const [key, value] of map) {
+      unionMap.set(key, value);
+    }
+  }
+  return unionMap;
+}
+
+export function mapFilter<T, X>(
+  map: Map<T, X>,
+  selector: (key: T, value: X) => boolean,
+): Map<T, X> {
+  const selected = new Map();
+  for (const [key, value] of map) {
+    if (selector(key, value)) {
+      selected.set(key, value);
+    }
+  }
+  return selected;
+}
+
+export function mapEqual<T, X>(
+  map1: Map<T, X>,
+  map2: Map<T, X>,
+) {
+  if (map1.size !== map2.size) {
+    return false;
+  }
+  for (const [key1, value1] of map1) {
+    if (map2.get(key1) !== value1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function setIntersect<T>(a: Set<T>, b: Set<T>): Set<T> {
+  return new Set(Array.from(a).filter(e => b.has(e)));
+}
+
+
+/**
+ * O(1)-check if a given object is empty (has no properties, inherited or not)
+ */
+export function isEmpty(obj: Object): boolean {
+  for (const key in obj) { // eslint-disable-line no-unused-vars
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Constructs an enumeration with keys equal to their value.
+ * e.g. keyMirror({a: null, b: null}) => {a: 'a', b: 'b'}
+ *
+ * Based off the equivalent function in www.
+ */
+export function keyMirror<T: Object>(obj: T): {[key: $Enum<T>]: $Enum<T>} {
+  const ret = {};
+  Object.keys(obj).forEach(key => {
+    ret[key] = key;
+  });
+  return ret;
+}
+
+/**
+ * Given an array of [key, value] pairs, construct a map where the values for
+ * each key are collected into an array of values, in order.
+ */
+export function collect<K, V>(pairs: Array<[K, V]>): Map<K, Array<V>> {
+  const result = new Map();
+  for (const pair of pairs) {
+    const [k, v] = pair;
+    let list = result.get(k);
+    if (list == null) {
+      list = [];
+      result.set(k, list);
+    }
+    list.push(v);
+  }
+  return result;
+}
+
+export class MultiMap<K, V> {
+  // Invariant: no empty sets. They should be removed instead.
+  _map: Map<K, Set<V>>;
+
+  // TODO may be worth defining a getter but no setter, to mimic Map. But please just behave and
+  // don't mutate this from outside this class.
+  //
+  // Invariant: equal to the sum of the sizes of all the sets contained in this._map
+  /* The total number of key-value bindings contained */
+  size: number;
+
+  constructor() {
+    this._map = new Map();
+    this.size = 0;
+  }
+
+  /*
+   * Returns the set of values associated with the given key. Do not mutate the given set. Copy it
+   * if you need to store it past the next operation on this MultiMap.
+   */
+  get(key: K): Set<V> {
+    const set = this._map.get(key);
+    if (set == null) {
+      return new Set();
+    }
+    return set;
+  }
+
+  /*
+   * Mimics the Map.prototype.set interface. Deliberately did not choose "set" as the name since the
+   * implication is that it removes the previous binding.
+   */
+  add(key: K, value: V): MultiMap<K, V> {
+    let set = this._map.get(key);
+    if (set == null) {
+      set = new Set();
+      this._map.set(key, set);
+    }
+    if (!set.has(value)) {
+      set.add(value);
+      this.size++;
+    }
+    return this;
+  }
+
+  /*
+   * Deletes a single binding. Returns true iff the binding existed.
+   */
+  delete(key: K, value: V): boolean {
+    const set = this.get(key);
+    const didRemove = set.delete(value);
+    if (set.size === 0) {
+      this._map.delete(key);
+    }
+    if (didRemove) {
+      this.size--;
+    }
+    return didRemove;
+  }
+
+  /*
+   * Deletes all bindings associated with the given key. Returns true iff any bindings were deleted.
+   */
+  deleteAll(key: K): boolean {
+    const set = this.get(key);
+    this.size -= set.size;
+    return this._map.delete(key);
+  }
+
+  clear(): void {
+    this._map.clear();
+    this.size = 0;
+  }
+
+  has(key: K, value: V): boolean {
+    return this.get(key).has(value);
+  }
+
+  hasAny(key: K): boolean {
+    return this._map.has(key);
+  }
+}

--- a/server/src/pkg/commons-node/debounce.js
+++ b/server/src/pkg/commons-node/debounce.js
@@ -1,0 +1,59 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import invariant from 'assert';
+
+export default function debounce<T: Function>(
+  func: T,
+  wait: number,
+  immediate?: boolean = false,
+): T {
+  // Taken from: https://github.com/jashkenas/underscore/blob/b10b2e6d72/underscore.js#L815.
+  let timeout;
+  let args: ?Array<any>;
+  let context;
+  let timestamp = 0;
+  let result;
+
+  const later = function() {
+    const last = Date.now() - timestamp;
+
+    if (last < wait && last >= 0) {
+      timeout = setTimeout(later, wait - last);
+    } else {
+      timeout = null;
+      if (!immediate) {
+        invariant(args);
+        result = func.apply(context, args);
+        if (!timeout) {
+          context = args = null;
+        }
+      }
+    }
+  };
+
+  // $FlowIssue -- Flow's type system isn't expressive enough to type debounce.
+  return function() {
+    context = this; // eslint-disable-line consistent-this
+    args = arguments;
+    timestamp = Date.now();
+    const callNow = immediate && !timeout;
+    if (!timeout) {
+      timeout = setTimeout(later, wait);
+    }
+    if (callNow) {
+      result = func.apply(context, args);
+      context = args = null;
+    }
+
+    return result;
+  };
+}

--- a/server/src/pkg/commons-node/event.js
+++ b/server/src/pkg/commons-node/event.js
@@ -1,0 +1,39 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import {Disposable} from 'event-kit';
+import {Observable} from 'rxjs';
+
+/**
+ * Add an event listener an return a disposable for removing it. Note that this function assumes
+ * node EventEmitter semantics: namely, that adding the same combination of eventName and callback
+ * adds a second listener.
+ */
+export function attachEvent(
+  emitter: events$EventEmitter,
+  eventName: string,
+  callback: Function,
+): Disposable {
+  emitter.addListener(eventName, callback);
+  return new Disposable(() => {
+    emitter.removeListener(eventName, callback);
+  });
+}
+
+type SubscribeCallback<T> = (item: T) => any;
+type SubscribeFunction<T> = (callback: SubscribeCallback<T>) => atom$IDisposable;
+
+export function observableFromSubscribeFunction<T>(fn: SubscribeFunction<T>): Observable<T> {
+  return Observable.create(observer => {
+    const disposable = fn(observer.next.bind(observer));
+    return () => { disposable.dispose(); };
+  });
+}

--- a/server/src/pkg/commons-node/fsPromise.js
+++ b/server/src/pkg/commons-node/fsPromise.js
@@ -1,0 +1,224 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import fs from 'fs-plus';
+import mkdirpLib from 'mkdirp';
+import nuclideUri from '../nuclide-remote-uri/lib/main';
+import rimraf from 'rimraf';
+import temp from 'temp';
+import {asyncExecute} from './process';
+
+/**
+ * Create a temp directory with given prefix. The caller is responsible for cleaning up the
+ *   drectory.
+ * @param prefix optinal prefix for the temp directory name.
+ * @return path to a temporary directory.
+ */
+function tempdir(prefix: string = ''): Promise<string> {
+  return new Promise((resolve, reject) => {
+    temp.mkdir(prefix, (err, dirPath) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(dirPath);
+      }
+    });
+  });
+}
+
+/**
+ * @return path to a temporary file. The caller is responsible for cleaning up
+ *     the file.
+ */
+function tempfile(options: any): Promise<string> {
+  return new Promise((resolve, reject) => {
+    temp.open(options, (err, info) => {
+      if (err) {
+        reject(err);
+      } else {
+        fs.close(info.fd, closeErr => {
+          if (closeErr) {
+            reject(closeErr);
+          } else {
+            resolve(info.path);
+          }
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Searches upward through the filesystem from pathToDirectory to find a file with
+ * fileName.
+ * @param fileName The name of the file to find.
+ * @param pathToDirectory Where to begin the search. Must be a path to a directory,
+ *   not a file.
+ * @return directory that contains the nearest file or null.
+ */
+async function findNearestFile(fileName: string, pathToDirectory: string): Promise<?string> {
+  // TODO(5586355): If this becomes a bottleneck, we should consider memoizing
+  // this function. The downside would be that if someone added a closer file
+  // with fileName to pathToFile (or deleted the one that was cached), then we
+  // would have a bug. This would probably be pretty rare, though.
+  let currentPath = nuclideUri.resolve(pathToDirectory);
+  do { // eslint-disable-line no-constant-condition
+    const fileToFind = nuclideUri.join(currentPath, fileName);
+    const hasFile = await exists(fileToFind); // eslint-disable-line babel/no-await-in-loop
+    if (hasFile) {
+      return currentPath;
+    }
+    if (nuclideUri.isRoot(currentPath)) {
+      return null;
+    }
+    currentPath = nuclideUri.dirname(currentPath);
+  } while (true);
+}
+
+/**
+ * Searches upward through the filesystem from pathToDirectory to find the furthest
+ * file with fileName.
+ * @param fileName The name of the file to find.
+ * @param pathToDirectory Where to begin the search. Must be a path to a directory,
+ *   not a file.
+ * @param stopOnMissing Stop searching when we reach a directory without fileName.
+ * @return directory that contains the furthest file or null.
+ */
+async function findFurthestFile(
+  fileName: string,
+  pathToDirectory: string,
+  stopOnMissing: boolean = false,
+): Promise<?string> {
+  let currentPath = nuclideUri.resolve(pathToDirectory);
+  let result = null;
+  do { // eslint-disable-line no-constant-condition
+    const fileToFind = nuclideUri.join(currentPath, fileName);
+    const hasFile = await exists(fileToFind); // eslint-disable-line babel/no-await-in-loop
+    if ((!hasFile && stopOnMissing) || nuclideUri.isRoot(currentPath)) {
+      return result;
+    } else if (hasFile) {
+      result = currentPath;
+    }
+    currentPath = nuclideUri.dirname(currentPath);
+  } while (true);
+}
+
+function getCommonAncestorDirectory(filePaths: Array<string>): string {
+  let commonDirectoryPath = nuclideUri.dirname(filePaths[0]);
+  while (filePaths.some(filePath => !filePath.startsWith(commonDirectoryPath))) {
+    commonDirectoryPath = nuclideUri.dirname(commonDirectoryPath);
+  }
+  return commonDirectoryPath;
+}
+
+
+function exists(filePath: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    fs.exists(filePath, resolve);
+  });
+}
+
+/**
+ * Runs the equivalent of `mkdir -p` with the given path.
+ *
+ * Like most implementations of mkdirp, if it fails, it is possible that
+ * directories were created for some prefix of the given path.
+ * @return true if the path was created; false if it already existed.
+ */
+async function mkdirp(filePath: string): Promise<boolean> {
+  const isExistingDirectory = await exists(filePath);
+  if (isExistingDirectory) {
+    return false;
+  } else {
+    return new Promise((resolve, reject) => {
+      mkdirpLib(filePath, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(true);
+        }
+      });
+    });
+  }
+}
+
+/**
+ * Removes directories even if they are non-empty. Does not fail if the directory doesn't exist.
+ */
+async function rmdir(filePath: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    rimraf(filePath, err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/** @return true only if we are sure directoryPath is on NFS. */
+async function isNfs(entityPath: string): Promise<boolean> {
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    const {stdout, exitCode} = await asyncExecute('stat', ['-f', '-L', '-c', '%T', entityPath]);
+    if (exitCode === 0) {
+      return stdout.trim() === 'nfs';
+    } else {
+      return false;
+    }
+  } else {
+    // TODO Handle other platforms (windows?): t9917576.
+    return false;
+  }
+}
+
+/**
+ * Takes a method from Node's fs module and returns a "denodeified" equivalent, i.e., an adapter
+ * with the same functionality, but returns a Promise rather than taking a callback. This isn't
+ * quite as efficient as Q's implementation of denodeify, but it's considerably less code.
+ */
+function _denodeifyFsMethod(methodName: string): () => Promise<any> {
+  return function(...args): Promise<any> {
+    const method = fs[methodName];
+    return new Promise((resolve, reject) => {
+      method.apply(fs, args.concat([
+        (err, result) => (err ? reject(err) : resolve(result)),
+      ]));
+    });
+  };
+}
+
+export default {
+  tempdir,
+  tempfile,
+  findNearestFile,
+  findFurthestFile,
+  getCommonAncestorDirectory,
+  exists,
+  mkdirp,
+  rmdir,
+  isNfs,
+
+  copy: _denodeifyFsMethod('copy'),
+  chmod: _denodeifyFsMethod('chmod'),
+  lstat: _denodeifyFsMethod('lstat'),
+  mkdir: _denodeifyFsMethod('mkdir'),
+  readdir: _denodeifyFsMethod('readdir'),
+  readFile: _denodeifyFsMethod('readFile'),
+  readlink: _denodeifyFsMethod('readlink'),
+  realpath: _denodeifyFsMethod('realpath'),
+  rename: _denodeifyFsMethod('rename'),
+  move: _denodeifyFsMethod('move'),
+  stat: _denodeifyFsMethod('stat'),
+  symlink: _denodeifyFsMethod('symlink'),
+  unlink: _denodeifyFsMethod('unlink'),
+  writeFile: _denodeifyFsMethod('writeFile'),
+};

--- a/server/src/pkg/commons-node/once.js
+++ b/server/src/pkg/commons-node/once.js
@@ -1,0 +1,25 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export default function once<T>(fn: () => T): () => T {
+  let ret;
+  return function(): T {
+    // The type gymnastics here are so `fn` can be
+    // garbage collected once we've used it.
+    if (!fn) {
+      return (ret: any);
+    } else {
+      ret = fn.apply(this, arguments);
+      fn = (null: any);
+      return ret;
+    }
+  };
+}

--- a/server/src/pkg/commons-node/package.json
+++ b/server/src/pkg/commons-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "commons-node",
+  "repository": "https://github.com/facebook/nuclide",
+  "version": "0.0.0",
+  "description": "Provides common utilities for other Nuclide packages",
+  "nuclide": {
+    "packageType": "Node",
+    "testRunner": "npm"
+  },
+  "scripts": {
+    "test": "node ../nuclide-jasmine/bin/jasmine-node-transpiled spec"
+  }
+}

--- a/server/src/pkg/commons-node/process-types.js
+++ b/server/src/pkg/commons-node/process-types.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Separated out for RPC usage.
+export type ProcessMessage = {
+  kind: 'stdout';
+  data: string;
+} | {
+  kind: 'stderr';
+  data: string;
+} | {
+  kind: 'exit';
+  exitCode: number;
+} | {
+  kind: 'error';
+  error: Object;
+};

--- a/server/src/pkg/commons-node/process.js
+++ b/server/src/pkg/commons-node/process.js
@@ -1,0 +1,681 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {Observer} from 'rxjs';
+import type {ProcessMessage} from './process-types';
+
+import child_process from 'child_process';
+import spawn from 'cross-spawn';
+import nuclideUri from '../nuclide-remote-uri/lib/main';
+import {CompositeSubscription, observeStream, splitStream, takeWhileInclusive} from './stream';
+import {Observable} from 'rxjs';
+import {PromiseQueue} from './promise-executors';
+import {quote} from 'shell-quote';
+
+export type process$asyncExecuteRet = {
+  // If the process fails to even start up, exitCode will not be set
+  // and errorCode / errorMessage will contain the actual error message.
+  // Otherwise, exitCode will always be defined.
+  command?: string;
+  errorMessage?: string;
+  errorCode?: string;
+  exitCode?: number;
+  stderr: string;
+  stdout: string;
+};
+
+type ProcessSystemErrorOptions = {
+  command: string;
+  args: Array<string>;
+  options: Object;
+  code: string;
+  originalError: Error;
+};
+
+export class ProcessSystemError extends Error {
+  command: string;
+  args: Array<string>;
+  options: Object;
+  code: string;
+  originalError: Error;
+
+  constructor(opts: ProcessSystemErrorOptions) {
+    super(`"${opts.command}" failed with code ${opts.code}`);
+    this.name = 'ProcessSystemError';
+    this.command = opts.command;
+    this.args = opts.args;
+    this.options = opts.options;
+    this.code = opts.code;
+    this.originalError = opts.originalError;
+  }
+}
+
+type ProcessExitErrorOptions = {
+  command: string;
+  args: Array<string>;
+  options: Object;
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+export class ProcessExitError extends Error {
+  command: string;
+  args: Array<string>;
+  options: Object;
+  code: number;
+  stdout: string;
+  stderr: string;
+
+  constructor(opts: ProcessExitErrorOptions) {
+    super(`"${opts.command}" failed with code ${opts.code}\n\n${opts.stderr}`);
+    this.name = 'ProcessExitError';
+    this.command = opts.command;
+    this.args = opts.args;
+    this.options = opts.options;
+    this.code = opts.code;
+    this.stdout = opts.stdout;
+    this.stderr = opts.stderr;
+  }
+}
+
+export type ProcessError = ProcessSystemError | ProcessExitError;
+
+export type AsyncExecuteOptions = child_process$spawnOpts & {
+  // The queue on which to block dependent calls.
+  queueName?: string;
+  // The contents to write to stdin.
+  stdin?: ?string;
+  // A command to pipe output through.
+  pipedCommand?: string;
+  // Arguments to the piped command.
+  pipedArgs?: Array<string>;
+  // Timeout (in milliseconds).
+  timeout?: number;
+};
+
+let platformPathPromise: ?Promise<string>;
+
+const blockingQueues = {};
+const COMMON_BINARY_PATHS = ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin'];
+
+/**
+ * Captures the value of the PATH env variable returned by Darwin's (OS X) `path_helper` utility.
+ * `path_helper -s`'s return value looks like this:
+ *
+ *     PATH="/usr/bin"; export PATH;
+ */
+const DARWIN_PATH_HELPER_REGEXP = /PATH="([^"]+)"/;
+
+const STREAM_NAMES = ['stdin', 'stdout', 'stderr'];
+
+function getPlatformPath(): Promise<string> {
+  // Do not return the cached value if we are executing under the test runner.
+  if (platformPathPromise && process.env.NODE_ENV !== 'test') {
+    // Path is being fetched, await the Promise that's in flight.
+    return platformPathPromise;
+  }
+
+  // We do not cache the result of this check because we have unit tests that temporarily redefine
+  // the value of process.platform.
+  if (process.platform === 'darwin') {
+    // OS X apps don't inherit PATH when not launched from the CLI, so reconstruct it. This is a
+    // bug, filed against Atom Linter here: https://github.com/AtomLinter/Linter/issues/150
+    // TODO(jjiaa): remove this hack when the Atom issue is closed
+    platformPathPromise = new Promise((resolve, reject) => {
+      child_process.execFile('/usr/libexec/path_helper', ['-s'], (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+        } else {
+          const match = stdout.toString().match(DARWIN_PATH_HELPER_REGEXP);
+          resolve((match && match.length > 1) ? match[1] : '');
+        }
+      });
+    });
+  } else {
+    platformPathPromise = Promise.resolve('');
+  }
+
+  return platformPathPromise;
+}
+
+/**
+ * Since OS X apps don't inherit PATH when not launched from the CLI, this function creates a new
+ * environment object given the original environment by modifying the env.PATH using following
+ * logic:
+ *  1) If originalEnv.PATH doesn't equal to process.env.PATH, which means the PATH has been
+ *    modified, we shouldn't do anything.
+ *  1) If we are running in OS X, use `/usr/libexec/path_helper -s` to get the correct PATH and
+ *    REPLACE the PATH.
+ *  2) If step 1 failed or we are not running in OS X, APPEND commonBinaryPaths to current PATH.
+ */
+export async function createExecEnvironment(
+  originalEnv: Object,
+  commonBinaryPaths: Array<string>,
+): Promise<Object> {
+  const execEnv = {...originalEnv};
+
+  if (execEnv.PATH !== process.env.PATH) {
+    return execEnv;
+  }
+
+  execEnv.PATH = execEnv.PATH || '';
+
+  let platformPath = null;
+  try {
+    platformPath = await getPlatformPath();
+  } catch (error) {
+    logError('Failed to getPlatformPath', error);
+  }
+
+  // If the platform returns a non-empty PATH, use it. Otherwise use the default set of common
+  // binary paths.
+  if (platformPath) {
+    execEnv.PATH = platformPath;
+  } else if (commonBinaryPaths.length) {
+    const paths = nuclideUri.splitPathList(execEnv.PATH);
+    commonBinaryPaths.forEach(commonBinaryPath => {
+      if (paths.indexOf(commonBinaryPath) === -1) {
+        paths.push(commonBinaryPath);
+      }
+    });
+    execEnv.PATH = nuclideUri.joinPathList(paths);
+  }
+
+  return execEnv;
+}
+
+function logError(...args) {
+  // Can't use nuclide-logging here to not cause cycle dependency.
+  /*eslint-disable no-console*/
+  console.error(...args);
+  /*eslint-enable no-console*/
+}
+
+function monitorStreamErrors(process: child_process$ChildProcess, command, args, options): void {
+  STREAM_NAMES.forEach(streamName => {
+    // $FlowIssue
+    const stream = process[streamName];
+    if (stream == null) {
+      return;
+    }
+    stream.on('error', error => {
+      // This can happen without the full execution of the command to fail,
+      // but we want to learn about it.
+      logError(
+        `stream error on stream ${streamName} with command:`,
+        command,
+        args,
+        options,
+        'error:',
+        error,
+      );
+    });
+  });
+}
+
+/**
+ * Basically like spawn, except it handles and logs errors instead of crashing
+ * the process. This is much lower-level than asyncExecute. Unless you have a
+ * specific reason you should use asyncExecute instead.
+ */
+export async function safeSpawn(
+  command: string,
+  args?: Array<string> = [],
+  options?: Object = {},
+): Promise<child_process$ChildProcess> {
+  options.env = await createExecEnvironment(options.env || process.env, COMMON_BINARY_PATHS);
+  const child = spawn(command, args, options);
+  monitorStreamErrors(child, command, args, options);
+  child.on('error', error => {
+    logError('error with command:', command, args, options, 'error:', error);
+  });
+  return child;
+}
+
+export async function forkWithExecEnvironment(
+  modulePath: string,
+  args?: Array<string> = [],
+  options?: Object = {},
+): Promise<child_process$ChildProcess> {
+  const forkOptions = {
+    ...options,
+    env: await createExecEnvironment(options.env || process.env, COMMON_BINARY_PATHS),
+  };
+  const child = child_process.fork(modulePath, args, forkOptions);
+  child.on('error', error => {
+    logError('error from module:', modulePath, args, options, 'error:', error);
+  });
+  return child;
+}
+
+/**
+ * Takes the command and args that you would normally pass to `spawn()` and returns `newArgs` such
+ * that you should call it with `spawn('script', newArgs)` to run the original command/args pair
+ * under `script`.
+ */
+export function createArgsForScriptCommand(
+  command: string,
+  args?: Array<string> = [],
+): Array<string> {
+  if (process.platform === 'darwin') {
+    // On OS X, script takes the program to run and its arguments as varargs at the end.
+    return ['-q', '/dev/null', command].concat(args);
+  } else {
+    // On Linux, script takes the command to run as the -c parameter.
+    const allArgs = [command].concat(args);
+    return ['-q', '/dev/null', '-c', quote(allArgs)];
+  }
+}
+
+/**
+ * Basically like safeSpawn, but runs the command with the `script` command.
+ * `script` ensures terminal-like environment and commands we run give colored output.
+ */
+export function scriptSafeSpawn(
+  command: string,
+  args?: Array<string> = [],
+  options?: Object = {},
+): Promise<child_process$ChildProcess> {
+  const newArgs = createArgsForScriptCommand(command, args);
+  return safeSpawn('script', newArgs, options);
+}
+
+/**
+ * Wraps scriptSafeSpawn with an Observable that lets you listen to the stdout and
+ * stderr of the spawned process.
+ */
+export function scriptSafeSpawnAndObserveOutput(
+  command: string,
+  args?: Array<string> = [],
+  options?: Object = {},
+): Observable<{stderr?: string; stdout?: string;}> {
+  return Observable.create((observer: Observer<any>) => {
+    let childProcess;
+    scriptSafeSpawn(command, args, options).then(proc => {
+      childProcess = proc;
+
+      childProcess.stdout.on('data', data => {
+        observer.next({stdout: data.toString()});
+      });
+
+      let stderr = '';
+      childProcess.stderr.on('data', data => {
+        stderr += data;
+        observer.next({stderr: data.toString()});
+      });
+
+      childProcess.on('exit', (exitCode: number) => {
+        if (exitCode !== 0) {
+          observer.error(stderr);
+        } else {
+          observer.complete();
+        }
+        childProcess = null;
+      });
+    });
+
+    return () => {
+      if (childProcess) {
+        childProcess.kill();
+      }
+    };
+  });
+}
+
+/**
+ * Creates an observable with the following properties:
+ *
+ * 1. It contains a process that's created using the provided factory upon subscription.
+ * 2. It doesn't complete until the process exits (or errors).
+ * 3. The process is killed when there are no more subscribers.
+ *
+ * IMPORTANT: The exit event does NOT mean that all stdout and stderr events have been received.
+ */
+function _createProcessStream(
+  createProcess: () => child_process$ChildProcess | Promise<child_process$ChildProcess>,
+  throwOnError: boolean,
+): Observable<child_process$ChildProcess> {
+  return Observable.create(observer => {
+    const promise = Promise.resolve(createProcess());
+    let process;
+    let disposed = false;
+    let exited = false;
+    const maybeKill = () => {
+      if (process != null && disposed && !exited) {
+        process.kill();
+        process = null;
+      }
+    };
+
+    promise.then(p => {
+      process = p;
+      maybeKill();
+    });
+
+    // Create a stream that contains the process but never completes. We'll use this to build the
+    // completion conditions.
+    const processStream = Observable.fromPromise(promise).merge(Observable.never());
+
+    const errors = processStream.switchMap(p => Observable.fromEvent(p, 'error'));
+    const exit = processStream
+      .flatMap(p => Observable.fromEvent(p, 'exit', (code, signal) => signal))
+      // An exit signal from SIGUSR1 doesn't actually exit the process, so skip that.
+      .filter(signal => signal !== 'SIGUSR1')
+      .do(() => { exited = true; });
+    const completion = throwOnError ? exit : exit.race(errors);
+
+    return new CompositeSubscription(
+      processStream
+        .merge(throwOnError ? errors.flatMap(Observable.throw) : Observable.empty())
+        .takeUntil(completion)
+        .subscribe(observer),
+      () => { disposed = true; maybeKill(); },
+    );
+  });
+  // TODO: We should really `.share()` this observable, but there seem to be issues with that and
+  //   `.retry()` in Rx 3 and 4. Once we upgrade to Rx5, we should share this observable and verify
+  //   that our retry logic (e.g. in adb-logcat) works.
+}
+
+export function createProcessStream(
+  createProcess: () => child_process$ChildProcess | Promise<child_process$ChildProcess>,
+): Observable<child_process$ChildProcess> {
+  return _createProcessStream(createProcess, true);
+}
+
+/**
+ * Observe the stdout, stderr and exit code of a process.
+ * stdout and stderr are split by newlines.
+ */
+export function observeProcessExit(
+  createProcess: () => child_process$ChildProcess | Promise<child_process$ChildProcess>,
+): Observable<number> {
+  return _createProcessStream(createProcess, false)
+    .flatMap(process => Observable.fromEvent(process, 'exit').take(1));
+}
+
+export function getOutputStream(
+  childProcess: child_process$ChildProcess | Promise<child_process$ChildProcess>,
+): Observable<ProcessMessage> {
+  return Observable.fromPromise(Promise.resolve(childProcess))
+    .flatMap(process => {
+      // We need to start listening for the exit event immediately, but defer emitting it until the
+      // output streams end.
+      const exit = Observable.fromEvent(process, 'exit')
+        .take(1)
+        .map(exitCode => ({kind: 'exit', exitCode}))
+        .publishReplay();
+      const exitSub = exit.connect();
+
+      const error = Observable.fromEvent(process, 'error')
+        .map(errorObj => ({kind: 'error', error: errorObj}));
+      const stdout = splitStream(observeStream(process.stdout))
+        .map(data => ({kind: 'stdout', data}));
+      const stderr = splitStream(observeStream(process.stderr))
+        .map(data => ({kind: 'stderr', data}));
+
+      return takeWhileInclusive(
+        Observable.merge(
+          Observable.merge(stdout, stderr).concat(exit),
+          error,
+        ),
+        event => event.kind !== 'error' && event.kind !== 'exit',
+      )
+        .finally(() => { exitSub.unsubscribe(); });
+    });
+}
+
+/**
+ * Observe the stdout, stderr and exit code of a process.
+ */
+export function observeProcess(
+  createProcess: () => child_process$ChildProcess | Promise<child_process$ChildProcess>,
+): Observable<ProcessMessage> {
+  return _createProcessStream(createProcess, false).flatMap(getOutputStream);
+}
+
+/**
+ * Returns a promise that resolves to the result of executing a process.
+ *
+ * @param command The command to execute.
+ * @param args The arguments to pass to the command.
+ * @param options Options for changing how to run the command.
+ *     Supports the options listed here: http://nodejs.org/api/child_process.html
+ *     in addition to the custom options listed in AsyncExecuteOptions.
+ */
+export function asyncExecute(
+  command: string,
+  args: Array<string>,
+  options: ?AsyncExecuteOptions = {},
+): Promise<process$asyncExecuteRet> {
+  // Clone passed in options so this function doesn't modify an object it doesn't own.
+  const localOptions = {...options};
+
+  const executor = (resolve, reject) => {
+    let firstChild;
+    let lastChild;
+
+    let firstChildStderr;
+    if (localOptions.pipedCommand) {
+      // If a second command is given, pipe stdout of first to stdin of second. String output
+      // returned in this function's Promise will be stderr/stdout of the second command.
+      firstChild = spawn(command, args, localOptions);
+      monitorStreamErrors(firstChild, command, args, localOptions);
+      firstChildStderr = '';
+
+      firstChild.on('error', error => {
+        // Resolve early with the result when encountering an error.
+        resolve({
+          command: [command].concat(args).join(' '),
+          errorMessage: error.message,
+          errorCode: error.code,
+          stderr: firstChildStderr,
+          stdout: '',
+        });
+      });
+
+      if (firstChild.stderr != null) {
+        firstChild.stderr.on('data', data => {
+          firstChildStderr += data;
+        });
+      }
+
+      lastChild = spawn(
+        localOptions.pipedCommand,
+        localOptions.pipedArgs,
+        localOptions
+      );
+      monitorStreamErrors(lastChild, command, args, localOptions);
+      // pipe() normally pauses the writer when the reader errors (closes).
+      // This is not how UNIX pipes work: if the reader closes, the writer needs
+      // to also close (otherwise the writer process may hang.)
+      // We have to manually close the writer in this case.
+      if (lastChild.stdin != null && firstChild.stdout != null) {
+        lastChild.stdin.on('error', () => {
+          firstChild.stdout.emit('end');
+        });
+        firstChild.stdout.pipe(lastChild.stdin);
+      }
+
+    } else {
+      lastChild = spawn(command, args, localOptions);
+      monitorStreamErrors(lastChild, command, args, localOptions);
+      firstChild = lastChild;
+    }
+
+    let stderr = '';
+    let stdout = '';
+    let timeout = null;
+    if (localOptions.timeout != null) {
+      timeout = setTimeout(() => {
+        // Prevent the other handlers from firing.
+        lastChild.removeAllListeners();
+        lastChild.kill();
+        resolve({
+          command: [command].concat(args).join(' '),
+          errorMessage: `Exceeded timeout of ${localOptions.timeout}ms`,
+          errorCode: 'ETIMEDOUT',
+          stderr,
+          stdout,
+        });
+      }, localOptions.timeout);
+    }
+
+    lastChild.on('close', exitCode => {
+      resolve({
+        exitCode,
+        stderr,
+        stdout,
+      });
+      if (timeout != null) {
+        clearTimeout(timeout);
+      }
+    });
+
+    lastChild.on('error', error => {
+      // Return early with the result when encountering an error.
+      resolve({
+        command: [command].concat(args).join(' '),
+        errorMessage: error.message,
+        errorCode: error.code,
+        stderr,
+        stdout,
+      });
+      if (timeout != null) {
+        clearTimeout(timeout);
+      }
+    });
+
+    if (lastChild.stderr != null) {
+      lastChild.stderr.on('data', data => {
+        stderr += data;
+      });
+    }
+    if (lastChild.stdout != null) {
+      lastChild.stdout.on('data', data => {
+        stdout += data;
+      });
+    }
+
+    if (typeof localOptions.stdin === 'string' && firstChild.stdin != null) {
+      // Note that the Node docs have this scary warning about stdin.end() on
+      // http://nodejs.org/api/child_process.html#child_process_child_stdin:
+      //
+      // "A Writable Stream that represents the child process's stdin. Closing
+      // this stream via end() often causes the child process to terminate."
+      //
+      // In practice, this has not appeared to cause any issues thus far.
+      firstChild.stdin.write(localOptions.stdin);
+      firstChild.stdin.end();
+    }
+  };
+
+  function makePromise(): Promise<process$asyncExecuteRet> {
+    if (localOptions.queueName === undefined) {
+      return new Promise(executor);
+    } else {
+      if (!blockingQueues[localOptions.queueName]) {
+        blockingQueues[localOptions.queueName] = new PromiseQueue();
+      }
+      return blockingQueues[localOptions.queueName].submit(executor);
+    }
+  }
+
+  return createExecEnvironment(localOptions.env || process.env, COMMON_BINARY_PATHS).then(
+    val => {
+      localOptions.env = val;
+      return makePromise();
+    },
+    error => {
+      localOptions.env = localOptions.env || process.env;
+      return makePromise();
+    }
+  );
+}
+
+/**
+ * Simple wrapper around asyncExecute that throws if the exitCode is non-zero.
+ */
+export async function checkOutput(
+  command: string,
+  args: Array<string>,
+  options: ?AsyncExecuteOptions = {},
+): Promise<process$asyncExecuteRet> {
+  const result = await asyncExecute(command, args, options);
+  if (result.exitCode !== 0) {
+    const reason = result.exitCode != null ? `exitCode: ${result.exitCode}` :
+      `error: ${String(result.errorMessage)}`;
+    throw new Error(
+      `asyncExecute "${command}" failed with ${reason}, ` +
+      `stderr: ${String(result.stderr)}, stdout: ${String(result.stdout)}.`
+    );
+  }
+  return result;
+}
+
+/**
+ * Run a command, accumulate the output. Errors are surfaced as stream errors and unsubscribing will
+ * kill the process.
+ */
+export function runCommand(
+  command: string,
+  args?: Array<string> = [],
+  options?: Object = {},
+): Observable<string> {
+  return observeProcess(() => safeSpawn(command, args, options))
+    .reduce(
+      (acc, event) => {
+        switch (event.kind) {
+          case 'stdout':
+            acc.stdout += event.data;
+            break;
+          case 'stderr':
+            acc.stderr += event.data;
+            break;
+          case 'error':
+            acc.error = event.error;
+            break;
+          case 'exit':
+            acc.exitCode = event.exitCode;
+            break;
+        }
+        return acc;
+      },
+      {error: ((null: any): Object), stdout: '', stderr: '', exitCode: ((null: any): ?number)},
+    )
+    .map(acc => {
+      if (acc.error != null) {
+        throw new ProcessSystemError({
+          command,
+          args,
+          options,
+          code: acc.error.code, // Alias of errno
+          originalError: acc.error, // Just in case.
+        });
+      }
+      if (acc.exitCode != null && acc.exitCode !== 0) {
+        throw new ProcessExitError({
+          command,
+          args,
+          options,
+          code: acc.exitCode,
+          stdout: acc.stdout,
+          stderr: acc.stderr,
+        });
+      }
+      return acc.stdout;
+    });
+}
+
+export const __test__ = {
+  DARWIN_PATH_HELPER_REGEXP,
+};

--- a/server/src/pkg/commons-node/promise-executors.js
+++ b/server/src/pkg/commons-node/promise-executors.js
@@ -1,0 +1,109 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import Dequeue from 'dequeue';
+import EventEmitter from 'events';
+
+type Executor = (resolve: any, reject: any) => any;
+
+/**
+ * A pool that executes Promise executors in parallel given the poolSize, in order.
+ *
+ * The executor function passed to the constructor of a Promise is evaluated
+ * immediately. This may not always be desirable. Use a PromisePool if you have
+ * a sequence of async operations that need to be run in parallel and you also want
+ * control the number of concurrent executions.
+ */
+export class PromisePool {
+  _fifo: Dequeue;
+  _emitter: EventEmitter;
+  _numPromisesRunning: number;
+  _poolSize: number;
+  _nextRequestId: number;
+
+  constructor(poolSize: number) {
+    this._fifo = new Dequeue();
+    this._emitter = new EventEmitter();
+    this._numPromisesRunning = 0;
+    this._poolSize = poolSize;
+    this._nextRequestId = 1;
+  }
+
+  /**
+   * @param executor A function that takes resolve and reject callbacks, just
+   *     like the Promise constructor.
+   * @return A Promise that will be resolved/rejected in response to the
+   *     execution of the executor.
+   */
+  submit(executor: Executor): Promise<any> {
+    const id = this._getNextRequestId();
+    this._fifo.push({id, executor});
+    const promise = new Promise((resolve, reject) => {
+      this._emitter.once(id, result => {
+        const {isSuccess, value} = result;
+        (isSuccess ? resolve : reject)(value);
+      });
+    });
+    this._run();
+    return promise;
+  }
+
+  _run() {
+    if (this._numPromisesRunning === this._poolSize) {
+      return;
+    }
+
+    if (this._fifo.length === 0) {
+      return;
+    }
+
+    const {id, executor} = this._fifo.shift();
+    this._numPromisesRunning++;
+    new Promise(executor).then(result => {
+      this._emitter.emit(id, {isSuccess: true, value: result});
+      this._numPromisesRunning--;
+      this._run();
+    }, error => {
+      this._emitter.emit(id, {isSuccess: false, value: error});
+      this._numPromisesRunning--;
+      this._run();
+    });
+  }
+
+  _getNextRequestId(): string {
+    return (this._nextRequestId++).toString(16);
+  }
+}
+
+/**
+ * FIFO queue that executes Promise executors one at a time, in order.
+ *
+ * The executor function passed to the constructor of a Promise is evaluated
+ * immediately. This may not always be desirable. Use a PromiseQueue if you have
+ * a sequence of async operations that need to use a shared resource serially.
+ */
+export class PromiseQueue {
+  _promisePool: PromisePool;
+
+  constructor() {
+    this._promisePool = new PromisePool(1);
+  }
+
+  /**
+   * @param executor A function that takes resolve and reject callbacks, just
+   *     like the Promise constructor.
+   * @return A Promise that will be resolved/rejected in response to the
+   *     execution of the executor.
+   */
+  submit(executor: Executor): Promise<any> {
+    return this._promisePool.submit(executor);
+  }
+}

--- a/server/src/pkg/commons-node/promise.js
+++ b/server/src/pkg/commons-node/promise.js
@@ -1,0 +1,475 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import invariant from 'assert';
+
+type RunReturn<T> = {
+  status: 'success';
+  result: T;
+} | {
+  status: 'outdated';
+};
+
+/**
+ * Allows a caller to ensure that the results it receives from consecutive
+ * promise resolutions are never outdated. Usage:
+ *
+ * var requestSerializer = new RequestSerializer();
+ *
+ * // in some later loop:
+ *
+ * // note that you do not await the async function here -- you must pass the
+ * // promise it returns to `run`
+ * var result = await requestSerializer.run(someAsyncFunction())
+ *
+ * if (result.status === 'success') {
+ *   ....
+ *   result.result
+ * } else if (result.status === 'outdated') {
+ *   ....
+ * }
+ *
+ * The contract is that the status is 'success' if and only if this was the most
+ * recently dispatched call of 'run'. For example, if you call run(promise1) and
+ * then run(promise2), and promise2 resolves first, the second callsite would
+ * receive a 'success' status. If promise1 later resolved, the first callsite
+ * would receive an 'outdated' status.
+ */
+export class RequestSerializer<T> {
+  _lastDispatchedOp: number;
+  _lastFinishedOp: number;
+  _latestPromise: Promise<T>;
+  _waitResolve: Function;
+
+  constructor() {
+    this._lastDispatchedOp = 0;
+    this._lastFinishedOp = 0;
+    this._latestPromise = new Promise((resolve, reject) => {
+      this._waitResolve = resolve;
+    });
+  }
+
+  async run(promise: Promise<T>): Promise<RunReturn<T>> {
+    const thisOp = this._lastDispatchedOp + 1;
+    this._lastDispatchedOp = thisOp;
+    this._latestPromise = promise;
+    this._waitResolve();
+    const result = await promise;
+    if (this._lastFinishedOp < thisOp) {
+      this._lastFinishedOp = thisOp;
+      return {
+        status: 'success',
+        result,
+      };
+    } else {
+      return {
+        status: 'outdated',
+      };
+    }
+  }
+
+  /**
+   * Returns a Promise that resolves to the last result of `run`,
+   * as soon as there are no more outstanding `run` calls.
+   */
+  async waitForLatestResult(): Promise<T> {
+    let lastPromise = null;
+    let result: any = null;
+    /* eslint-disable babel/no-await-in-loop */
+    while (lastPromise !== this._latestPromise) {
+      lastPromise = this._latestPromise;
+      // Wait for the current last know promise to resolve, or a next run have started.
+      result = await new Promise((resolve, reject) => {
+        this._waitResolve = resolve;
+        this._latestPromise.then(resolve);
+      });
+    }
+    /* eslint-enable babel/no-await-in-loop */
+    return (result: T);
+  }
+
+  isRunInProgress(): boolean {
+    return this._lastDispatchedOp > this._lastFinishedOp;
+  }
+}
+
+
+/*
+ * Returns a promise that will resolve after `milliSeconds` milli seconds.
+ * this can be used to pause execution asynchronously.
+ * e.g. await sleep(1000), pauses the async flow execution for 1 second.
+ */
+export function sleep(milliSeconds: number): Promise<void> {
+  return new Promise(resolve => { setTimeout(resolve, milliSeconds); });
+}
+
+/**
+ * Executes a provided callback only if a promise takes longer than
+ * `milliSeconds` milliseconds to resolve.
+ *
+ * @param `promise` the promise to wait on.
+ * @param `milliSeconds` max amount of time that `promise` can take to resolve
+ * before timeoutFn is fired.
+ * @param `timeoutFn` the function to execute when a promise takes longer than
+ * `milliSeconds` ms to resolve.
+ * @param `cleanupFn` the cleanup function to execute after the promise resolves.
+ */
+export async function triggerAfterWait<T>(
+  promise: Promise<T>,
+  milliSeconds: number,
+  timeoutFn: () => void,
+  cleanupFn?: () => void,
+): Promise<T> {
+  const timeout = setTimeout(timeoutFn, milliSeconds);
+  try {
+    return await promise;
+  } finally {
+    clearTimeout(timeout);
+    if (cleanupFn) {
+      cleanupFn();
+    }
+  }
+}
+
+/**
+ * Call an async function repeatedly with a maximum number of trials limit,
+ * until a valid result that's defined by a validation function.
+ * A failed call can result from an async thrown exception, or invalid result.
+ *
+ * @param `retryFunction` the async logic that's wanted to be retried.
+ * @param `validationFunction` the validation function that decides whether a response is valid.
+ * @param `maximumTries` the number of times the `retryFunction` can fail to get a valid
+ * response before the `retryLimit` is terminated reporting an error.
+ * @param `retryIntervalMs` optional, the number of milliseconds to wait between trials, if wanted.
+ *
+ * If an exception is encountered on the last trial, the exception is thrown.
+ * If no valid response is found, an exception is thrown.
+ */
+export async function retryLimit<T>(
+  retryFunction: () => Promise<T>,
+  validationFunction: (result: T) => boolean,
+  maximumTries: number,
+  retryIntervalMs?: number = 0,
+): Promise<T> {
+  let result = null;
+  let tries = 0;
+  let lastError = null;
+  /* eslint-disable babel/no-await-in-loop */
+  while (tries === 0 || tries < maximumTries) {
+    try {
+      result = await retryFunction();
+      lastError = null;
+      if (validationFunction(result)) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+      result = null;
+    }
+
+    if (++tries < maximumTries && retryIntervalMs !== 0) {
+      await sleep(retryIntervalMs);
+    }
+  }
+  /* eslint-enable babel/no-await-in-loop */
+  if (lastError != null) {
+    throw lastError;
+  } else if (tries === maximumTries) {
+    throw new Error('No valid response found!');
+  } else {
+    return ((result: any): T);
+  }
+}
+
+/**
+ * Limits async function execution parallelism to only one at a time.
+ * Hence, if a call is already running, it will wait for it to finish,
+ * then start the next async execution, but if called again while not finished,
+ * it will return the scheduled execution promise.
+ *
+ * Sample Usage:
+ * ```
+ * let i = 1;
+ * const oneExecAtATime = oneParallelAsyncCall(() => {
+ *   return next Promise((resolve, reject) => {
+ *     setTimeout(200, () => resolve(i++));
+ *   });
+ * });
+ *
+ * const result1Promise = oneExecAtATime(); // Start an async, and resolve to 1 in 200 ms.
+ * const result2Promise = oneExecAtATime(); // Schedule the next async, and resolve to 2 in 400 ms.
+ * const result3Promise = oneExecAtATime(); // Reuse scheduled promise and resolve to 2 in 400 ms.
+ * ```
+ */
+export function serializeAsyncCall<T>(asyncFun: () => Promise<T>): () => Promise<T> {
+  let scheduledCall = null;
+  let pendingCall = null;
+  const startAsyncCall = () => {
+    const resultPromise = asyncFun();
+    pendingCall = resultPromise.then(
+      () => (pendingCall = null),
+      () => (pendingCall = null),
+    );
+    return resultPromise;
+  };
+  const callNext = () => {
+    scheduledCall = null;
+    return startAsyncCall();
+  };
+  const scheduleNextCall = () => {
+    if (scheduledCall == null) {
+      invariant(pendingCall, 'pendingCall must not be null!');
+      scheduledCall = pendingCall.then(callNext, callNext);
+    }
+    return scheduledCall;
+  };
+  return () => {
+    if (pendingCall == null) {
+      return startAsyncCall();
+    } else {
+      return scheduleNextCall();
+    }
+  };
+}
+
+/**
+ * Provides a promise along with methods to change its state. Our version of the non-standard
+ * `Promise.defer()`.
+ *
+ * IMPORTANT: This should almost never be used!! Instead, use the Promise constructor. See
+ *  <https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns#the-deferred-anti-pattern>
+ */
+export class Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+/**
+ * Returns a value derived asynchronously from an element in the items array.
+ * The test function is applied sequentially to each element in items until
+ * one returns a Promise that resolves to a non-null value. When this happens,
+ * the Promise returned by this method will resolve to that non-null value. If
+ * no such Promise is produced, then the Promise returned by this function
+ * will resolve to null.
+ *
+ * @param items Array of elements that will be passed to test, one at a time.
+ * @param test Will be called with each item and must return either:
+ *     (1) A "thenable" (i.e, a Promise or promise-like object) that resolves
+ *         to a derived value (that will be returned) or null.
+ *     (2) null.
+ *     In both cases where null is returned, test will be applied to the next
+ *     item in the array.
+ * @param thisArg Receiver that will be used when test is called.
+ * @return Promise that resolves to an asynchronously derived value or null.
+ */
+export function asyncFind<T, U>(
+  items: Array<T>,
+  test: (t: T) => ?Promise<U>,
+  thisArg?: mixed,
+): Promise<?U> {
+  return new Promise((resolve, reject) => {
+    // Create a local copy of items to defend against the caller modifying the
+    // array before this Promise is resolved.
+    items = items.slice();
+    const numItems = items.length;
+
+    const next = async function(index) {
+      if (index === numItems) {
+        resolve(null);
+        return;
+      }
+
+      const item = items[index];
+      const result = await test.call(thisArg, item);
+      if (result !== null) {
+        resolve(result);
+      } else {
+        next(index + 1);
+      }
+    };
+
+    next(0);
+  });
+}
+
+export function denodeify(
+  f: (...args: Array<any>) => any,
+): (...args: Array<any>) => Promise<any> {
+  return function(...args: Array<any>) {
+    return new Promise((resolve, reject) => {
+      function callback(error, result) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      }
+      f.apply(this, args.concat([callback]));
+    });
+  };
+}
+
+/**
+ * A Promise utility that runs a maximum of limit async operations at a time
+ * iterating over an array and returning the result of executions.
+ * e.g. to limit the number of file reads to 5,
+ * replace the code:
+ *    var fileContents = await Promise.all(filePaths.map(fsPromise.readFile))
+ * with:
+ *    var fileContents = await asyncLimit(filePaths, 5, fsPromise.readFile)
+ *
+ * This is particulrily useful to limit IO operations to a configurable maximum (to avoid
+ * blocking), while enjoying the configured level of parallelism.
+ *
+ * @param array the array of items for iteration.
+ * @param limit the configurable number of parallel async operations.
+ * @param mappingFunction the async Promise function that could return a useful result.
+ */
+export function asyncLimit<T, V>(
+  array: Array<T>,
+  limit: number,
+  mappingFunction: (item: T) => Promise<V>,
+): Promise<Array<V>> {
+  const result: Array<V> = new Array(array.length);
+  let parallelPromises = 0;
+  let index = 0;
+
+  let parallelLimit = Math.min(limit, array.length) || 1;
+
+  return new Promise((resolve, reject) => {
+    const runPromise = async () => {
+      if (index === array.length) {
+        if (parallelPromises === 0) {
+          resolve(result);
+        }
+        return;
+      }
+      ++parallelPromises;
+      const i = index++;
+      try {
+        result[i] = await mappingFunction(array[i]);
+      } catch (e) {
+        reject(e);
+      }
+      --parallelPromises;
+      runPromise();
+    };
+
+    while (parallelLimit--) {
+      runPromise();
+    }
+  });
+}
+
+/**
+ * `filter` Promise utility that allows filtering an array with an async Promise function.
+ * It's an alternative to `Array.prototype.filter` that accepts an async function.
+ * You can optionally configure a limit to set the maximum number of async operations at a time.
+ *
+ * Previously, with the `Promise.all` primitive, we can't set the parallelism limit and we have to
+ * `filter`, so, we replace the old `filter` code:
+ *     var existingFilePaths = [];
+ *     await Promise.all(filePaths.map(async (filePath) => {
+ *       if (await fsPromise.exists(filePath)) {
+ *         existingFilePaths.push(filePath);
+ *       }
+ *     }));
+ * with limit 5 parallel filesystem operations at a time:
+ *    var existingFilePaths = await asyncFilter(filePaths, fsPromise.exists, 5);
+ *
+ * @param array the array of items for `filter`ing.
+ * @param filterFunction the async `filter` function that returns a Promise that resolves to a
+ *   boolean.
+ * @param limit the configurable number of parallel async operations.
+ */
+export async function asyncFilter<T>(
+  array: Array<T>,
+  filterFunction: (item: T) => Promise<boolean>,
+  limit?: number,
+): Promise<Array<T>> {
+  const filteredList = [];
+  await asyncLimit(array, limit || array.length, async (item: T) => {
+    if (await filterFunction(item)) {
+      filteredList.push(item);
+    }
+  });
+  return filteredList;
+}
+
+export async function asyncObjFilter<T>(
+  obj: {[key: string]: T},
+  filterFunction: (item: T, key: string) => Promise<boolean>,
+  limit?: number,
+): Promise<{[key: string]: T}> {
+  const keys = Object.keys(obj);
+  const filteredObj = {};
+  await asyncLimit(keys, limit || keys.length, async (key: string) => {
+    const item = obj[key];
+    if (await filterFunction(item, key)) {
+      filteredObj[key] = item;
+    }
+  });
+  return filteredObj;
+}
+
+/**
+ * `some` Promise utility that allows `some` an array with an async Promise some function.
+ * It's an alternative to `Array.prototype.some` that accepts an async some function.
+ * You can optionally configure a limit to set the maximum number of async operations at a time.
+ *
+ * Previously, with the Promise.all primitive, we can't set the parallelism limit and we have to
+ * `some`, so, we replace the old `some` code:
+ *     var someFileExist = false;
+ *     await Promise.all(filePaths.map(async (filePath) => {
+ *       if (await fsPromise.exists(filePath)) {
+ *         someFileExist = true;
+ *       }
+ *     }));
+ * with limit 5 parallel filesystem operations at a time:
+ *    var someFileExist = await asyncSome(filePaths, fsPromise.exists, 5);
+ *
+ * @param array the array of items for `some`ing.
+ * @param someFunction the async `some` function that returns a Promise that resolves to a
+ *   boolean.
+ * @param limit the configurable number of parallel async operations.
+ */
+export async function asyncSome<T>(
+  array: Array<T>,
+  someFunction: (item: T) => Promise<boolean>,
+  limit?: number,
+): Promise<boolean> {
+  let resolved = false;
+  await asyncLimit(array, limit || array.length, async (item: T) => {
+    if (resolved) {
+      // We don't need to call the someFunction anymore or wait any longer.
+      return;
+    }
+    if (await someFunction(item)) {
+      resolved = true;
+    }
+  });
+  return resolved;
+}
+
+/**
+ * Check if an object is Promise by testing if it has a `then` function property.
+ */
+export function isPromise(object: any): boolean {
+  return Boolean(object) && typeof object === 'object' && typeof object.then === 'function';
+}

--- a/server/src/pkg/commons-node/singleton.js
+++ b/server/src/pkg/commons-node/singleton.js
@@ -1,0 +1,57 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+
+const GLOBAL_MAP_NAME = '__NUCLIDE_SINGLETONS__';
+
+function getMap(): Map<string, any> {
+  let map = global[GLOBAL_MAP_NAME];
+  if (!map) {
+    map = global[GLOBAL_MAP_NAME] = new Map();
+  }
+  return map;
+}
+
+/**
+ * Creates a per-global singleton value.
+ * constructor will be called exactly once, future invocations will
+ * return the result of the constructor call.
+ */
+function get<T>(field: string, constructor: () => T): T {
+  const map = getMap();
+  if (!map.has(field)) {
+    map.set(field, constructor());
+  }
+  // Cast through `any` because `map.get` can return null/undefined. We know that `field` exists
+  // because we have just checked it above. However, we cannot just call `get` and then check it
+  // against null because T may be a nullable type, in which case this would break subtly. So, we
+  // circumvent the type system here to maintain the desired runtime behavior.
+  return (map.get(field): any);
+}
+
+function clear(field: string): void {
+  getMap().delete(field);
+}
+
+function reset<T>(field: string, constructor: () => T): T {
+  clear(field);
+  return get(field, constructor);
+}
+
+export default {
+  // Disable Object shorthand on the following line because an issue in Flow prevents using
+  // shorthand with the reserved word "get" (among others).
+  //
+  // eslint-disable-next-line babel/object-shorthand
+  get: get,
+  clear,
+  reset,
+};

--- a/server/src/pkg/commons-node/stream.js
+++ b/server/src/pkg/commons-node/stream.js
@@ -1,0 +1,253 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import invariant from 'assert';
+import {CompositeDisposable, Disposable} from 'event-kit';
+import {Observable, ReplaySubject, Subscription} from 'rxjs';
+
+/**
+ * Observe a stream like stdout or stderr.
+ */
+export function observeStream(stream: stream$Readable): Observable<string> {
+  return observeRawStream(stream).map(data => data.toString());
+}
+
+export function observeRawStream(stream: stream$Readable): Observable<Buffer> {
+  const error = Observable.fromEvent(stream, 'error').flatMap(Observable.throw);
+  return Observable
+    .fromEvent(stream, 'data')
+    .merge(error)
+    .takeUntil(Observable.fromEvent(stream, 'end'));
+}
+
+/**
+ * Splits a stream of strings on newlines.
+ * Includes the newlines in the resulting stream.
+ * Sends any non-newline terminated data before closing.
+ * Never sends an empty string.
+ */
+export function splitStream(input: Observable<string>): Observable<string> {
+  return Observable.create(observer => {
+    let current: string = '';
+
+    function onEnd() {
+      if (current !== '') {
+        observer.next(current);
+        current = '';
+      }
+    }
+
+    return input.subscribe(
+      value => {
+        const lines = (current + value).split('\n');
+        current = lines.pop();
+        lines.forEach(line => observer.next(line + '\n'));
+      },
+      error => { onEnd(); observer.error(error); },
+      () => { onEnd(); observer.complete(); },
+    );
+  });
+}
+
+export class DisposableSubscription {
+  _subscription: rx$ISubscription;
+
+  constructor(subscription: rx$ISubscription) {
+    this._subscription = subscription;
+  }
+
+  dispose(): void {
+    this._subscription.unsubscribe();
+  }
+}
+
+type TeardownLogic = (() => void) | rx$ISubscription;
+
+export class CompositeSubscription {
+  _subscription: Subscription;
+
+  constructor(...subscriptions: Array<TeardownLogic>) {
+    this._subscription = new Subscription();
+    subscriptions.forEach(sub => {
+      this._subscription.add(sub);
+    });
+  }
+
+  unsubscribe(): void {
+    this._subscription.unsubscribe();
+  }
+}
+
+// TODO: We used to use `stream.buffer(stream.filter(...))` for this but it doesn't work in RxJS 5.
+//  See https://github.com/ReactiveX/rxjs/issues/1610
+export function bufferUntil<T>(
+  stream: Observable<T>,
+  condition: (item: T) => boolean,
+): Observable<Array<T>> {
+  return Observable.create(observer => {
+    let buffer = null;
+    const flush = () => {
+      if (buffer != null) {
+        observer.next(buffer);
+        buffer = null;
+      }
+    };
+    return stream
+      .subscribe(
+        x => {
+          if (buffer == null) {
+            buffer = [];
+          }
+          buffer.push(x);
+          if (condition(x)) {
+            flush();
+          }
+        },
+        err => {
+          flush();
+          observer.error(err);
+        },
+        () => {
+          flush();
+          observer.complete();
+        },
+      );
+  });
+}
+
+/**
+ * Like Observable.prototype.cache(1) except it forgets the cached value when there are no
+ * subscribers. This is useful so that if consumers unsubscribe and then subscribe much later, they
+ * do not get an ancient cached value.
+ *
+ * This is intended to be used with cold Observables. If you have a hot Observable, `cache(1)` will
+ * be just fine because the hot Observable will continue producing values even when there are no
+ * subscribers, so you can be assured that the cached values are up-to-date.
+ */
+export function cacheWhileSubscribed<T>(input: Observable<T>): Observable<T> {
+  return input.multicast(() => new ReplaySubject(1)).refCount();
+}
+
+type Diff<T> = {
+  added: Set<T>;
+  removed: Set<T>;
+};
+
+function subtractSet<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const result = new Set();
+  a.forEach(value => {
+    if (!b.has(value)) {
+      result.add(value);
+    }
+  });
+  return result;
+}
+
+/**
+ * Shallowly compare two Sets.
+ */
+function setsAreEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const item of a) {
+    if (!b.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Given a stream of sets, return a stream of diffs.
+ * **IMPORTANT:** These sets are assumed to be immutable by convention. Don't mutate them!
+ */
+export function diffSets<T>(stream: Observable<Set<T>>): Observable<Diff<T>> {
+  return Observable.concat(
+      Observable.of(new Set()), // Always start with no items with an empty set
+      stream,
+    )
+    .distinctUntilChanged(setsAreEqual)
+    .pairwise()
+    .map(([previous, next]) => ({
+      added: subtractSet(next, previous),
+      removed: subtractSet(previous, next),
+    }));
+}
+
+/**
+ * Give a stream of diffs, perform an action for each added item and dispose of the returned
+ * disposable when the item is removed.
+ */
+export function reconcileSetDiffs<T>(
+  diffs: Observable<Diff<T>>,
+  addAction: (addedItem: T) => atom$IDisposable,
+): atom$IDisposable {
+  const itemsToDisposables = new Map();
+  const disposeItem = item => {
+    const disposable = itemsToDisposables.get(item);
+    invariant(disposable != null);
+    disposable.dispose();
+    itemsToDisposables.delete(item);
+  };
+  const disposeAll = () => {
+    itemsToDisposables.forEach(disposable => { disposable.dispose(); });
+    itemsToDisposables.clear();
+  };
+
+  return new CompositeDisposable(
+    new DisposableSubscription(
+      diffs.subscribe(diff => {
+        // For every item that got added, perform the add action.
+        diff.added.forEach(item => { itemsToDisposables.set(item, addAction(item)); });
+
+        // "Undo" the add action for each item that got removed.
+        diff.removed.forEach(disposeItem);
+      })
+    ),
+    new Disposable(disposeAll),
+  );
+}
+
+export function toggle<T>(
+  source: Observable<T>,
+  toggler: Observable<boolean>,
+): Observable<T> {
+  return toggler
+    .distinctUntilChanged()
+    .switchMap(enabled => (enabled ? source : Observable.empty()));
+}
+
+export function compact<T>(source: Observable<?T>): Observable<T> {
+  // Flow does not understand the semantics of `filter`
+  return (source.filter(x => x != null): any);
+}
+
+/**
+ * Like `takeWhile`, but includes the first item that doesn't match the predicate.
+ */
+export function takeWhileInclusive<T>(
+  source: Observable<T>,
+  predicate: (value: T) => boolean,
+): Observable<T> {
+  return Observable.create(observer => (
+    source.subscribe(
+      x => {
+        observer.next(x);
+        if (!predicate(x)) {
+          observer.complete();
+        }
+      },
+      err => { observer.error(err); },
+      () => { observer.complete(); },
+    )
+  ));
+}

--- a/server/src/pkg/commons-node/string.js
+++ b/server/src/pkg/commons-node/string.js
@@ -1,0 +1,80 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export function stringifyError(error: Error): string {
+  return `name: ${error.name}, message: ${error.message}, stack: ${error.stack}.`;
+}
+
+// As of Flow v0.28, Flow does not alllow implicit string coercion of null or undefined. Use this to
+// make it explicit.
+export function maybeToString(str: ?string): string {
+  // We don't want to encourage the use of this function directly because it coerces anything to a
+  // string. We get stricter typechecking by using maybeToString, so it should generally be
+  // preferred.
+  return String(str);
+}
+
+/**
+ * Originally adapted from https://github.com/azer/relative-date.
+ * We're including it because of https://github.com/npm/npm/issues/12012
+ */
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const YEAR = DAY * 365;
+const MONTH = YEAR / 12;
+
+const formats = [
+  [0.7 * MINUTE, 'just now'],
+  [1.5 * MINUTE, 'a minute ago'],
+  [60 * MINUTE, 'minutes ago', MINUTE],
+  [1.5 * HOUR, 'an hour ago'],
+  [DAY, 'hours ago', HOUR],
+  [2 * DAY, 'yesterday'],
+  [7 * DAY, 'days ago', DAY],
+  [1.5 * WEEK, 'a week ago'],
+  [MONTH, 'weeks ago', WEEK],
+  [1.5 * MONTH, 'a month ago'],
+  [YEAR, 'months ago', MONTH],
+  [1.5 * YEAR, 'a year ago'],
+  [Number.MAX_VALUE, 'years ago', YEAR],
+];
+
+export function relativeDate(
+  input: number | Date,
+  reference?: number | Date,
+): string {
+  if (input instanceof Date) {
+    input = input.getTime();
+  }
+  if (!reference) {
+    reference = new Date().getTime();
+  }
+  if (reference instanceof Date) {
+    reference = reference.getTime();
+  }
+
+  const delta = reference - input;
+
+  for (const [limit, relativeFormat, remainder] of formats) {
+    if (delta < limit) {
+      if (typeof remainder === 'number') {
+        return Math.round(delta / remainder) + ' ' + relativeFormat;
+      } else {
+        return relativeFormat;
+      }
+    }
+  }
+
+  throw new Error('This should never be reached.');
+}

--- a/server/src/pkg/commons-node/system-info.js
+++ b/server/src/pkg/commons-node/system-info.js
@@ -1,0 +1,131 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import fs from 'fs';
+import invariant from 'assert';
+import once from './once';
+import os from 'os';
+import nuclideUri from '../nuclide-remote-uri/lib/main';
+import {checkOutput} from './process';
+
+const NUCLIDE_PACKAGE_JSON_PATH = require.resolve('../../../package.json');
+const NUCLIDE_BASEDIR = nuclideUri.dirname(NUCLIDE_PACKAGE_JSON_PATH);
+
+const pkgJson = JSON.parse(fs.readFileSync(NUCLIDE_PACKAGE_JSON_PATH).toString());
+
+export const OS_TYPE = {
+  WIN32: 'win32',
+  WIN64: 'win64',
+  LINUX: 'linux',
+  OSX: 'darwin',
+};
+
+// "Development" is defined as working from source - not packaged code.
+// apm/npm and internal releases don't package the base `.flowconfig`, so
+// we use this to figure if we're packaged or not.
+export const isDevelopment = once((): boolean => {
+  try {
+    fs.statSync(nuclideUri.join(NUCLIDE_BASEDIR, '.flowconfig'));
+    return true;
+  } catch (err) {
+    return false;
+  }
+});
+
+// Prior to Atom v1.7.0, `atom.inSpecMode` had a chance of performing an IPC call that could be
+// expensive depending on how much work the other process was doing. Because this value will not
+// change during run time, memoize the value to ensure the IPC call is performed only once.
+//
+// See [`getWindowLoadSettings`][1] for the sneaky getter and `remote` call that this memoization
+// ensures happens only once.
+//
+// [1]: https://github.com/atom/atom/blob/v1.6.2/src/window-load-settings-helpers.coffee#L10-L14
+export const isRunningInTest = once((): boolean => {
+  if (isRunningInClient()) {
+    return atom.inSpecMode();
+  } else {
+    return process.env.NODE_ENV === 'test';
+  }
+});
+
+export function isRunningInClient(): boolean {
+  return typeof atom !== 'undefined';
+}
+
+// This path may be a symlink.
+export function getAtomNuclideDir(): string {
+  if (!isRunningInClient()) {
+    throw Error('Not running in Atom.');
+  }
+  const nuclidePackageModule = atom.packages.getLoadedPackage('nuclide');
+  invariant(nuclidePackageModule);
+  return nuclidePackageModule.path;
+}
+
+export function getAtomVersion(): string {
+  if (!isRunningInClient()) {
+    throw Error('Not running in Atom.');
+  }
+  return atom.getVersion();
+}
+
+export function getNuclideVersion(): string {
+  return pkgJson.version;
+}
+
+export function getNuclideRealDir(): string {
+  return NUCLIDE_BASEDIR;
+}
+
+export function getOsType(): string {
+  return os.platform();
+}
+
+export function isRunningInWindows(): boolean {
+  return getOsType() === OS_TYPE.WIN32 || getOsType() === OS_TYPE.WIN64;
+}
+
+export function getOsVersion(): string {
+  return os.release();
+}
+
+export async function getFlowVersion(): Promise<string> {
+  // $UPFixMe: This should use nuclide-features-config
+  const flowPath = global.atom && global.atom.config.get('nuclide-flow.pathToFlow') || 'flow';
+  const {stdout} = await checkOutput(flowPath, ['--version']);
+  return stdout.trim();
+}
+
+export async function getClangVersion(): Promise<string> {
+  const {stdout} = await checkOutput('clang', ['--version']);
+  return stdout.trim();
+}
+
+export function getRuntimePath(): string {
+  // "resourcesPath" only exists in Atom. It's as close as you can get to
+  // Atom's path. In the general case, it looks like this:
+  // Mac: "/Applications/Atom.app/Contents/Resources"
+  // Linux: "/usr/share/atom/resources"
+  // Windows: "C:\\Users\\asuarez\\AppData\\Local\\atom\\app-1.6.2\\resources"
+  //          "C:\Atom\resources"
+  if (global.atom && typeof process.resourcesPath === 'string') {
+    const resourcesPath = process.resourcesPath;
+    if (os.platform() === 'darwin') {
+      return resourcesPath.replace(/\/Contents\/Resources$/, '');
+    } else if (os.platform() === 'linux') {
+      return resourcesPath.replace(/\/resources$/, '');
+    } else {
+      return resourcesPath.replace(/[\\]+resources$/, '');
+    }
+  } else {
+    return process.execPath;
+  }
+}

--- a/server/src/pkg/commons-node/userInfo.js
+++ b/server/src/pkg/commons-node/userInfo.js
@@ -1,0 +1,48 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+/**
+ * Similar to https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_userinfo_options
+ * Provides the same type structure as `os.userInfo` but with only the info that
+ * we use. If we need more, consider https://github.com/sindresorhus/user-info
+ */
+
+import os from 'os';
+
+export type UserInfo = {
+  uid: number;
+  gid: number;
+  username: string;
+  homedir: string;
+  shell: ?string;
+};
+
+export default function(): UserInfo {
+  return {
+    uid: -1,
+    gid: -1,
+    username: getUsername(),
+    homedir: os.homedir(),
+    shell: null,
+  };
+}
+
+// https://github.com/sindresorhus/username/blob/21344db/index.js
+function getUsername() {
+  return (
+    process.env.SUDO_USER ||
+    process.env.LOGNAME ||
+    process.env.USER ||
+    process.env.LNAME ||
+    process.env.USERNAME ||
+    ''
+  );
+}

--- a/server/src/pkg/commons-node/vcs.js
+++ b/server/src/pkg/commons-node/vcs.js
@@ -1,0 +1,58 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import {asyncExecute} from './process';
+import nuclideUri from '../nuclide-remote-uri/lib/main';
+
+type VcsInfo = {
+  vcs: string;
+  root: string;
+};
+
+const vcsInfoCache: {[src: string]: VcsInfo} = {};
+
+async function findVcsHelper(src: string): Promise<VcsInfo> {
+  const options = {
+    cwd: nuclideUri.dirname(src),
+  };
+  const hgResult = await asyncExecute('hg', ['root'], options);
+  if (hgResult.exitCode === 0) {
+    return {
+      vcs: 'hg',
+      root: hgResult.stdout.trim(),
+    };
+  }
+
+  const gitResult = await asyncExecute('git', ['rev-parse', '--show-toplevel'], options);
+  if (gitResult.exitCode === 0) {
+    return {
+      vcs: 'git',
+      root: gitResult.stdout.trim(),
+    };
+  }
+
+  throw new Error('Could not find VCS for: ' + src);
+}
+
+/**
+ * For the given source file, find the type of vcs that is managing it as well
+ * as the root directory for the VCS.
+ */
+export async function findVcs(src: string): Promise<VcsInfo> {
+  let vcsInfo = vcsInfoCache[src];
+  if (vcsInfo) {
+    return vcsInfo;
+  }
+
+  vcsInfo = await findVcsHelper(src);
+  vcsInfoCache[src] = vcsInfo;
+  return vcsInfo;
+}

--- a/server/src/pkg/flow-base/lib/FlowConstants.js
+++ b/server/src/pkg/flow-base/lib/FlowConstants.js
@@ -1,0 +1,32 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {ServerStatusType} from '..';
+
+export const ServerStatus = Object.freeze({
+  FAILED: 'failed',
+  UNKNOWN: 'unknown',
+  NOT_RUNNING: 'not running',
+  NOT_INSTALLED: 'not installed',
+  BUSY: 'busy',
+  INIT: 'init',
+  READY: 'ready',
+});
+
+// If we put this type on the definition, use sites will not see the individual properties in the
+// Server object for things like autocomplete. Worse, Flow will assume that *any* string key will
+// yield a valid ServerStatus result, so we won't get protection against typos. Adding this
+// assertion here ensures that all of the values are valid ServerStatus options, while yielding
+// better Flow behavior at use sites.
+(ServerStatus: { [key: string]: ServerStatusType });
+
+// Controls how long the Flow version will be cached before it is considered invalid.
+export const VERSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes in ms

--- a/server/src/pkg/flow-base/lib/FlowHelpers.js
+++ b/server/src/pkg/flow-base/lib/FlowHelpers.js
@@ -1,0 +1,259 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {LRUCache} from 'lru-cache';
+
+import type {FlowLocNoSource} from './flowOutputTypes';
+
+import nuclideUri from '../../nuclide-remote-uri/lib/main';
+import {checkOutput} from '../../commons-node/process';
+import fsPromise from '../../commons-node/fsPromise';
+import LRU from 'lru-cache';
+import invariant from 'assert';
+
+import {getLogger} from '../../nuclide-logging/lib/main';
+const logger = getLogger();
+
+const flowConfigDirCache: LRUCache<string, Promise<?string>> = LRU({
+  max: 10,
+  maxAge: 1000 * 30, //30 seconds
+});
+const flowPathCache: LRUCache<string, boolean> = LRU({
+  max: 10,
+  maxAge: 1000 * 30, // 30 seconds
+});
+
+function insertAutocompleteToken(contents: string, line: number, col: number): string {
+  const lines = contents.split('\n');
+  let theLine = lines[line];
+  theLine = theLine.substring(0, col) + 'AUTO332' + theLine.substring(col);
+  lines[line] = theLine;
+  return lines.join('\n');
+}
+
+/**
+ * Takes an autocomplete item from Flow and returns a valid autocomplete-plus
+ * response, as documented here:
+ * https://github.com/atom/autocomplete-plus/wiki/Provider-API
+ */
+function processAutocompleteItem(replacementPrefix: string, flowItem: Object): Object {
+  // Truncate long types for readability
+  const description = flowItem.type.length < 80
+    ? flowItem.type
+    : flowItem.type.substring(0, 80) + ' ...';
+  let result = {
+    description,
+    displayText: flowItem.name,
+    replacementPrefix,
+  };
+  const funcDetails = flowItem.func_details;
+  if (funcDetails) {
+    // The parameters in human-readable form for use on the right label.
+    const rightParamStrings = funcDetails.params
+      .map(param => `${param.name}: ${param.type}`);
+    const snippetString = getSnippetString(funcDetails.params.map(param => param.name));
+    result = {
+      ...result,
+      leftLabel: funcDetails.return_type,
+      rightLabel: `(${rightParamStrings.join(', ')})`,
+      snippet: `${flowItem.name}(${snippetString})`,
+      type: 'function',
+    };
+  } else {
+    result = {
+      ...result,
+      rightLabel: flowItem.type,
+      text: flowItem.name,
+    };
+  }
+  return result;
+}
+
+function getSnippetString(paramNames: Array<string>): string {
+  const groupedParams = groupParamNames(paramNames);
+  // The parameters turned into snippet strings.
+  const snippetParamStrings = groupedParams
+    .map(params => params.join(', '))
+    .map((param, i) => `\${${i + 1}:${param}}`);
+  return snippetParamStrings.join(', ');
+}
+
+/**
+ * Group the parameter names so that all of the trailing optional parameters are together with the
+ * last non-optional parameter. That makes it easy to ignore the optional parameters, since they
+ * will be selected along with the last non-optional parameter and you can just type to overwrite
+ * them.
+ */
+function groupParamNames(paramNames: Array<string>): Array<Array<string>> {
+  // Split the parameters into two groups -- all of the trailing optional paramaters, and the rest
+  // of the parameters. Trailing optional means all optional parameters that have only optional
+  // parameters after them.
+  const [ordinaryParams, trailingOptional] =
+    paramNames.reduceRight(([ordinary, optional], param) => {
+      // If there have only been optional params so far, and this one is optional, add it to the
+      // list of trailing optional params.
+      if (isOptional(param) && ordinary.length === 0) {
+        optional.unshift(param);
+      } else {
+        ordinary.unshift(param);
+      }
+      return [ordinary, optional];
+    },
+    [[], []]
+  );
+
+  const groupedParams = ordinaryParams.map(param => [param]);
+  const lastParam = groupedParams[groupedParams.length - 1];
+  if (lastParam != null) {
+    lastParam.push(...trailingOptional);
+  } else if (trailingOptional.length > 0) {
+    groupedParams.push(trailingOptional);
+  }
+
+  return groupedParams;
+}
+
+function isOptional(param: string): boolean {
+  invariant(param.length > 0);
+  const lastChar = param[param.length - 1];
+  return lastChar === '?';
+}
+
+function clearWorkspaceCaches() {
+  flowPathCache.reset();
+  flowConfigDirCache.reset();
+  global.cachedPathToFlowBin = undefined;
+}
+
+async function isFlowInstalled(): Promise<boolean> {
+  const flowPath = await getPathToFlow();
+  if (!flowPathCache.has(flowPath)) {
+    flowPathCache.set(flowPath, await canFindFlow(flowPath));
+  }
+
+  return flowPathCache.get(flowPath);
+}
+
+async function canFindFlow(flowPath: string): Promise<boolean> {
+  try {
+    // https://github.com/facebook/nuclide/issues/561
+    const {command, args} = buildSearchFlowCommand(flowPath)
+    await checkOutput(command, args);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * @return The path to Flow on the user's machine. First using the the user's 
+ *   config, then looking into the node_modules for the project.
+ * 
+ *   It is cached, so it is expected that changing the users settings will 
+ *   trigger a call to `clearWorkspaceCaches`.
+ */
+
+async function getPathToFlow(): Promise<string> {
+  if (!global.cachedPathToFlowBin) {
+    const config = global.vscode.workspace.getConfiguration('flow');
+    const shouldUseNodeModule = config.get('useNPMPackagedFlow');
+    const userPath = config.get('pathToFlow');
+
+    if (shouldUseNodeModule && await canFindFlow(nodeModuleFlowLocation())){
+      global.cachedPathToFlowBin = nodeModuleFlowLocation();
+    } else if (await canFindFlow(userPath)) {
+      global.cachedPathToFlowBin = userPath;
+    } else {
+      global.cachedPathToFlowBin = "flow";
+    }
+
+    logger.info("Path to Flow: " + global.cachedPathToFlowBin);
+   }
+
+  return global.cachedPathToFlowBin
+}
+
+/**
+ * @return The potential path to Flow on the user's machine if they are using NPM/Yarn to manage
+ * their installs of flow.
+ */
+function nodeModuleFlowLocation(): string {
+  if (process.platform === 'win32') {
+    return `${global.vscode.workspace.rootPath}\\node_modules\\.bin\\flow.cmd`
+  } else {
+    return `${global.vscode.workspace.rootPath}/node_modules/.bin/flow`
+  }
+}
+
+/**
+ * @return The command and arguments used to test the presence of flow according to platform.
+ */
+function buildSearchFlowCommand(testPath: string): {command: string, args: Array<string>} {
+  if (process.platform !== 'win32') {
+    return {
+      command: 'which',
+      args: [testPath]
+    }
+  } else {
+    const splitCharLocation = testPath.lastIndexOf('\\')
+    const command = testPath.substring(splitCharLocation+1, testPath.length)
+    const searchDirectory = testPath.substring(0, splitCharLocation)
+    const args = !searchDirectory ? [command] : ['/r', searchDirectory, command]
+    return {
+      command: `${process.env.SYSTEMROOT || 'C:\\Windows'}\\System32\\where`,
+      args: args
+    }
+  }
+}
+
+function getStopFlowOnExit(): boolean {
+  // $UPFixMe: This should use nuclide-features-config
+  // Does not currently do so because this is an npm module that may run on the server.
+  if (global.vscode) {
+    return global.vscode.workspace.getConfiguration('flow').get('stopFlowOnExit')
+  }
+  return true;
+}
+
+function findFlowConfigDir(localFile: string): Promise<?string> {
+  if (!flowConfigDirCache.has(localFile)) {
+    const flowConfigDir = fsPromise.findNearestFile('.flowconfig', nuclideUri.dirname(localFile));
+    flowConfigDirCache.set(localFile, flowConfigDir);
+  }
+  return flowConfigDirCache.get(localFile);
+}
+
+function flowCoordsToAtomCoords(flowCoords: FlowLocNoSource): FlowLocNoSource {
+  return {
+    start: {
+      line: flowCoords.start.line - 1,
+      column: flowCoords.start.column - 1,
+    },
+    end: {
+      line: flowCoords.end.line - 1,
+      // Yes, this is inconsistent. Yes, it works as expected in practice.
+      column: flowCoords.end.column,
+    },
+  };
+}
+
+module.exports = {
+  buildSearchFlowCommand,
+  findFlowConfigDir,
+  getPathToFlow,
+  getStopFlowOnExit,
+  insertAutocompleteToken,
+  isFlowInstalled,
+  processAutocompleteItem,
+  groupParamNames,
+  flowCoordsToAtomCoords,
+  clearWorkspaceCaches
+};

--- a/server/src/pkg/flow-base/lib/FlowProcess.js
+++ b/server/src/pkg/flow-base/lib/FlowProcess.js
@@ -1,0 +1,354 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {process$asyncExecuteRet} from '../../commons-node/process';
+
+import type {ServerStatusType} from '..';
+
+import os from 'os';
+
+import {BehaviorSubject, Observable} from 'rxjs';
+
+import {getLogger} from '../../nuclide-logging/lib/main';
+const logger = getLogger();
+
+// import {track} from '../../nuclide-analytics';
+
+import {
+  asyncExecute,
+  safeSpawn,
+} from '../../commons-node/process';
+
+import {
+  isFlowInstalled,
+  getPathToFlow,
+  getStopFlowOnExit,
+} from './FlowHelpers';
+
+import {ServerStatus} from './FlowConstants';
+
+// Names modeled after https://github.com/facebook/flow/blob/master/src/common/flowExitStatus.ml
+export const FLOW_RETURN_CODES = {
+  ok: 0,
+  serverInitializing: 1,
+  typeError: 2,
+  noServerRunning: 6,
+  // This means that the server exists, but it is not responding, typically because it is busy doing
+  // other work.
+  outOfRetries: 7,
+  buildIdMismatch: 9,
+  unexpectedArgument: 64,
+};
+
+const SERVER_READY_TIMEOUT_MS = 10 * 1000;
+
+const EXEC_FLOW_RETRIES = 5;
+
+export class FlowProcess {
+  // If we had to start a Flow server, store the process here so we can kill it when we shut down.
+  _startedServer: ?child_process$ChildProcess;
+  // The current state of the Flow server in this directory
+  _serverStatus: BehaviorSubject<ServerStatusType>;
+  // The path to the directory where the .flowconfig is -- i.e. the root of the Flow project.
+  _root: string;
+
+  constructor(root: string) {
+    this._serverStatus = new BehaviorSubject(ServerStatus.UNKNOWN);
+    this._root = root;
+
+    this._serverStatus.subscribe(status => {
+      logger.info(`[${status}]: Flow server in ${this._root}`);
+    });
+
+    this._serverStatus.filter(x => x === ServerStatus.NOT_RUNNING).subscribe(() => {
+      this._startFlowServer();
+      this._pingServer();
+    });
+    function isBusyOrInit(status: ServerStatusType): boolean {
+      return status === ServerStatus.BUSY || status === ServerStatus.INIT;
+    }
+    this._serverStatus.filter(isBusyOrInit).subscribe(() => {
+      this._pingServer();
+    });
+
+    // this._serverStatus.filter(status => status === ServerStatus.FAILED).subscribe(() => {
+    //   track('flow-server-failed');
+    // });
+  }
+
+  dispose(): void {
+    this._serverStatus.complete();
+    if (this._startedServer && getStopFlowOnExit()) {
+      // The default, SIGTERM, does not reliably kill the flow servers.
+      this._startedServer.kill('SIGKILL');
+    }
+  }
+
+  /**
+   * If the Flow server fails we will not try to restart it again automatically. Calling this
+   * method lets us exit that state and retry.
+   */
+  allowServerRestart(): void {
+    if (this._serverStatus.getValue() === ServerStatus.FAILED) {
+      // We intentionally do not use _setServerStatus because leaving the FAILED state is a
+      // special-case that _setServerStatus does not allow.
+      this._serverStatus.next(ServerStatus.UNKNOWN);
+    }
+  }
+
+  getServerStatusUpdates(): Observable<ServerStatusType> {
+    return this._serverStatus.asObservable();
+  }
+
+  /**
+   * Returns null if Flow cannot be found.
+   */
+  async execFlow(
+    args: Array<any>,
+    options: Object,
+    waitForServer?: boolean = false,
+    suppressErrors?: boolean = false,
+  ): Promise<?process$asyncExecuteRet> {
+    const maxRetries = waitForServer ? EXEC_FLOW_RETRIES : 0;
+    if (this._serverStatus.getValue() === ServerStatus.FAILED) {
+      return null;
+    }
+    for (let i = 0; ; i++) {
+      try {
+        const result = await this._rawExecFlow( // eslint-disable-line babel/no-await-in-loop
+          args,
+          options,
+        );
+        return result;
+      } catch (e) {
+        const couldRetry = [ServerStatus.NOT_RUNNING, ServerStatus.INIT, ServerStatus.BUSY]
+          .indexOf(this._serverStatus.getValue()) !== -1;
+        if (i < maxRetries && couldRetry) {
+          await this._serverIsReady(); // eslint-disable-line babel/no-await-in-loop
+          // Then try again.
+        } else {
+          // If it couldn't retry, it means there was a legitimate error. If it could retry, we
+          // don't want to log because it just means the server is busy and we don't want to wait.
+          if (!couldRetry && !suppressErrors) {
+            // not sure what happened, but we'll let the caller deal with it
+            const pathToFlow = await getPathToFlow();
+            logger.error(`Flow failed: ${pathToFlow} ${args.join(' ')}. Error: ${JSON.stringify(e)}`);
+          }
+          throw e;
+        }
+        // try again
+      }
+    }
+    // otherwise flow complains
+    // eslint-disable-next-line no-unreachable
+    return null;
+  }
+
+  /** Starts a Flow server in the current root */
+  async _startFlowServer(): Promise<void> {
+    const pathToFlow = await getPathToFlow();
+    // `flow server` will start a server in the foreground. asyncExecute
+    // will not resolve the promise until the process exits, which in this
+    // case is never. We need to use spawn directly to get access to the
+    // ChildProcess object.
+    const serverProcess = await safeSpawn( // eslint-disable-line babel/no-await-in-loop
+      pathToFlow,
+      [
+        'server',
+        '--from', 'nuclide',
+        '--max-workers', this._getMaxWorkers().toString(),
+        this._root,
+      ],
+      this._getFlowExecOptions(),
+    );
+    const logIt = data => {
+      const pid = serverProcess.pid;
+      logger.debug(`flow server (${pid}): ${data}`);
+    };
+    serverProcess.stdout.on('data', logIt);
+    serverProcess.stderr.on('data', logIt);
+    serverProcess.on('exit', (code, signal) => {
+      // We only want to blacklist this root if the Flow processes
+      // actually failed, rather than being killed manually. It seems that
+      // if they are killed, the code is null and the signal is 'SIGTERM'.
+      // In the Flow crashes I have observed, the code is 2 and the signal
+      // is null. So, let's blacklist conservatively for now and we can
+      // add cases later if we observe Flow crashes that do not fit this
+      // pattern.
+      if (code === 2 && signal === null) {
+        logger.error('Flow server unexpectedly exited', this._root);
+        this._setServerStatus(ServerStatus.FAILED);
+      }
+    });
+    this._startedServer = serverProcess;
+  }
+
+  /** Execute Flow with the given arguments */
+  async _rawExecFlow(args: Array<any>, options?: Object = {}): Promise<?process$asyncExecuteRet> {
+    const installed = await isFlowInstalled();
+    if (!installed) {
+      this._updateServerStatus(null);
+      return null;
+    }
+    const flowOptions = this._getFlowExecOptions();
+    options = {...flowOptions, ...options};
+    args = [
+      ...args,
+      '--retry-if-init', 'false',
+      '--retries', '0',
+      '--no-auto-start',
+    ];
+    try {
+      const result = await FlowProcess.execFlowClient(args, options);
+      this._updateServerStatus(result);
+      return result;
+    } catch (e) {
+      this._updateServerStatus(e);
+      if (e.exitCode === FLOW_RETURN_CODES.typeError) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  _updateServerStatus(result: ?process$asyncExecuteRet): void {
+    let status;
+    if (result == null) {
+      status = ServerStatus.NOT_INSTALLED;
+    } else {
+      switch (result.exitCode) {
+        case FLOW_RETURN_CODES.ok:
+          // falls through
+        case FLOW_RETURN_CODES.typeError:
+          status = ServerStatus.READY;
+          break;
+        case FLOW_RETURN_CODES.serverInitializing:
+          status = ServerStatus.INIT;
+          break;
+        case FLOW_RETURN_CODES.noServerRunning:
+          status = ServerStatus.NOT_RUNNING;
+          break;
+        case FLOW_RETURN_CODES.outOfRetries:
+          status = ServerStatus.BUSY;
+          break;
+        case FLOW_RETURN_CODES.buildIdMismatch:
+          // If the version doesn't match, the server is automatically killed and the client
+          // returns 9.
+          logger.info('Killed flow server with incorrect version in', this._root);
+          status = ServerStatus.NOT_RUNNING;
+          break;
+        case FLOW_RETURN_CODES.unexpectedArgument:
+          // If we issued an unexpected argument we have learned nothing about the state of the Flow
+          // server. So, don't update.
+          return;
+        default:
+          logger.error(
+            `Unknown return code from Flow: ${String(result.exitCode)}`
+          );
+          status = ServerStatus.UNKNOWN;
+      }
+    }
+    this._setServerStatus(status);
+  }
+
+  _setServerStatus(status: ServerStatusType): void {
+    const currentStatus = this._serverStatus.getValue();
+    if (
+        // Avoid duplicate updates
+        status !== currentStatus &&
+        // Avoid moving the status away from FAILED, to let any existing  work die out when the
+        // server fails.
+        currentStatus !== ServerStatus.FAILED
+      ) {
+      this._serverStatus.next(status);
+    }
+  }
+
+  /** Ping the server until it leaves the current state */
+  async _pingServer(tries?: number = 5): Promise<void> {
+    const fromState = this._serverStatus.getValue();
+    let stateChanged = false;
+    this._serverStatus.filter(newState => newState !== fromState).first().subscribe(() => {
+      stateChanged = true;
+    });
+    for (let i = 0; !stateChanged && i < tries; i++) {
+      /* eslint-disable babel/no-await-in-loop */
+      await this._rawExecFlow(['status']).catch(() => null);
+      // Wait 1 second
+      await Observable.of(null).delay(1000).toPromise();
+      /* eslint-enable babel/no-await-in-loop */
+    }
+  }
+
+  /**
+   * Resolves when the server is ready or the request times out, as indicated by the result of the
+   * returned Promise.
+   */
+  _serverIsReady(): Promise<boolean> {
+    return this._serverStatus
+      .filter(x => x === ServerStatus.READY)
+      .map(() => true)
+      .race(Observable.of(false).delay(SERVER_READY_TIMEOUT_MS))
+      // If the stream is completed timeout will not return its default value and we will see an
+      // EmptyError. So, provide a defaultValue here so the promise resolves.
+      .first(null, null, false)
+      .toPromise();
+  }
+
+  /**
+  * If this returns null, then it is not safe to run flow.
+  */
+  _getFlowExecOptions(): {cwd: string} {
+    return {
+      cwd: this._root,
+      env: {
+        // Allows backtrace to be printed:
+        // http://caml.inria.fr/pub/docs/manual-ocaml/runtime.html#sec279
+        OCAMLRUNPARAM: 'b',
+        // Put this after so that if the user already has something set for OCAMLRUNPARAM we use
+        // that instead. They probably know what they're doing.
+        ...process.env,
+      },
+    };
+  }
+
+  _getMaxWorkers(): number {
+    return Math.max(os.cpus().length - 2, 1);
+  }
+
+  /**
+   * This should be used to execute Flow commands that do not rely on a Flow server. So, they do not
+   * need to be associated with a FlowProcess instance and they may be executed from any working
+   * directory.
+   *
+   * Note that using this method means that you get no guarantee that the Flow version specified in
+   * any given .flowconfig is the one that will be executed here, because it has no association with
+   * any given root. If you need this property, create an instance with the appropriate root and use
+   * execFlow.
+   */
+  static async execFlowClient(
+    args: Array<any>,
+    options?: Object = {},
+  ): Promise<?process$asyncExecuteRet> {
+    args = [
+      ...args,
+      '--from', 'nuclide',
+    ];
+    const pathToFlow = await getPathToFlow();
+    const ret = await asyncExecute(pathToFlow, args, options);
+    if (ret.exitCode !== 0) {
+      // TODO: bubble up the exit code via return value instead
+      throw ret;
+    }
+    return ret;
+  }
+}

--- a/server/src/pkg/flow-base/lib/FlowRoot.js
+++ b/server/src/pkg/flow-base/lib/FlowRoot.js
@@ -1,0 +1,427 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {Observable} from 'rxjs';
+import type {NuclideUri} from '../../nuclide-remote-uri/lib/main';
+import type {ServerStatusType, FlowCoverageResult} from '..';
+
+import type {
+  Diagnostics,
+  Loc,
+  FlowOutlineTree,
+} from '..';
+
+import {filter} from 'fuzzaldrin';
+import semver from 'semver';
+
+import {getLogger} from '../../nuclide-logging/lib/main';
+const logger = getLogger();
+
+import {
+  insertAutocompleteToken,
+  processAutocompleteItem,
+  flowCoordsToAtomCoords,
+} from './FlowHelpers';
+
+import {FlowProcess} from './FlowProcess';
+import {FlowVersion} from './FlowVersion';
+
+import {astToOutline} from './astToOutline';
+import {flowStatusOutputToDiagnostics} from './diagnosticsParser';
+
+/** Encapsulates all of the state information we need about a specific Flow root */
+export class FlowRoot {
+  // The path to the directory where the .flowconfig is -- i.e. the root of the Flow project.
+  _root: string;
+  _process: FlowProcess;
+  _version: FlowVersion;
+
+  constructor(root: string) {
+    this._root = root;
+    this._process = new FlowProcess(root);
+    this._version = new FlowVersion(() => this._flowGetVersion());
+    this._process.getServerStatusUpdates()
+      .filter(state => state === 'not running')
+      .subscribe(() => this._version.invalidateVersion());
+  }
+
+  dispose(): void {
+    this._process.dispose();
+  }
+
+  allowServerRestart(): void {
+    this._process.allowServerRestart();
+  }
+
+  getPathToRoot(): string {
+    return this._root;
+  }
+
+  getServerStatusUpdates(): Observable<ServerStatusType> {
+    return this._process.getServerStatusUpdates();
+  }
+
+  async flowFindDefinition(
+    file: NuclideUri,
+    currentContents: string,
+    line: number,
+    column: number,
+  ): Promise<?Loc> {
+    const options = {};
+    // We pass the current contents of the buffer to Flow via stdin.
+    // This makes it possible for get-def to operate on the unsaved content in
+    // the user's editor rather than what is saved on disk. It would be annoying
+    // if the user had to save before using the jump-to-definition feature to
+    // ensure he or she got accurate results.
+    options.stdin = currentContents;
+
+    const args = ['get-def', '--json', '--path', file, line, column];
+    try {
+      const result = await this._process.execFlow(args, options);
+      if (!result) {
+        return null;
+      }
+      const json = parseJSON(args, result.stdout);
+      if (json.path) {
+        return {
+          file: json.path,
+          point: {
+            line: json.line - 1,
+            column: json.start - 1,
+          },
+        };
+      } else {
+        return null;
+      }
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * If currentContents is null, it means that the file has not changed since
+   * it has been saved, so we can avoid piping the whole contents to the Flow
+   * process.
+   */
+  async flowFindDiagnostics(
+    file: NuclideUri,
+    currentContents: ?string,
+  ): Promise<?Diagnostics> {
+    await this._forceRecheck(file);
+
+    const options = {};
+
+    let args;
+    if (currentContents) {
+      options.stdin = currentContents;
+
+      // Currently, `flow check-contents` returns all of the errors in the
+      // project. It would be nice if it would use the path for filtering, as
+      // currently the client has to do the filtering.
+      args = ['check-contents', '--json', file];
+    } else {
+      // We can just use `flow status` if the contents are unchanged.
+      args = ['status', '--json', file];
+    }
+
+    let result;
+
+    try {
+      // Don't log errors if the command returns a nonzero exit code, because status returns nonzero
+      // if it is reporting any issues, even when it succeeds.
+      result = await this._process.execFlow(args, options, /* waitForServer */ true);
+      if (!result) {
+        return null;
+      }
+    } catch (e) {
+      // This codepath will be exercised when Flow finds type errors as the
+      // exit code will be non-zero. Note this codepath could also be exercised
+      // due to a logical error in Nuclide, so we try to differentiate.
+      if (e.exitCode !== undefined) {
+        result = e;
+      } else {
+        logger.error(e);
+        return null;
+      }
+    }
+
+    let json;
+    try {
+      json = parseJSON(args, result.stdout);
+    } catch (e) {
+      return null;
+    }
+
+    return flowStatusOutputToDiagnostics(this._root, json);
+  }
+
+  async flowGetAutocompleteSuggestions(
+    file: NuclideUri,
+    currentContents: string,
+    line: number,
+    column: number,
+    prefix: string,
+    activatedManually: boolean,
+  ): Promise<any> {
+    // We may want to make this configurable, but if it is ever higher than one we need to make sure
+    // it works properly when the user manually activates it (e.g. with ctrl+space). See
+    // https://github.com/atom/autocomplete-plus/issues/597
+    //
+    // If this is made configurable, consider using autocomplete-plus' minimumWordLength setting, as
+    // per https://github.com/atom/autocomplete-plus/issues/594
+    const minimumPrefixLength = 1;
+
+    // Allows completions to immediately appear when we are completing off of object properties.
+    // This also needs to be changed if minimumPrefixLength goes above 1, since after you type a
+    // single alphanumeric character, autocomplete-plus no longer includes the dot in the prefix.
+    const prefixHasDot = prefix.indexOf('.') !== -1;
+
+    // If it is just whitespace and punctuation, ignore it (this keeps us
+    // from eating leading dots).
+    const replacementPrefix = /^[\s.]*$/.test(prefix) ? '' : prefix;
+
+    if (!activatedManually && !prefixHasDot && replacementPrefix.length < minimumPrefixLength) {
+      return [];
+    }
+
+    const options = {};
+
+    const args = ['autocomplete', '--json', file];
+
+    options.stdin = insertAutocompleteToken(currentContents, line, column);
+    try {
+      const result = await this._process.execFlow(args, options);
+      if (!result) {
+        return [];
+      }
+      const json = parseJSON(args, result.stdout);
+      let resultsArray;
+      if (Array.isArray(json)) {
+        // Flow < v0.20.0
+        resultsArray = json;
+      } else {
+        // Flow >= v0.20.0. The output format was changed to support more detailed failure
+        // information.
+        resultsArray = json.result;
+      }
+      const candidates = resultsArray.map(item => processAutocompleteItem(replacementPrefix, item));
+      return filter(candidates, replacementPrefix, {key: 'displayText'});
+    } catch (e) {
+      return [];
+    }
+  }
+
+  async flowGetType(
+    file: NuclideUri,
+    currentContents: string,
+    line: number,
+    column: number,
+    includeRawType: boolean,
+  ): Promise<?{type: string; rawType: ?string}> {
+    const options = {};
+
+    options.stdin = currentContents;
+
+    line++;
+    column++;
+    const args =
+      ['type-at-pos', '--json', '--path', file, line, column];
+    if (includeRawType) {
+      args.push('--raw');
+    }
+
+    let output;
+    try {
+      const result = await this._process.execFlow(args, options);
+      if (!result) {
+        return null;
+      }
+      output = result.stdout;
+      if (output === '') {
+        // if there is a syntax error, Flow returns the JSON on stderr while
+        // still returning a 0 exit code (t8018595)
+        output = result.stderr;
+      }
+    } catch (e) {
+      return null;
+    }
+    let json;
+    try {
+      json = parseJSON(args, output);
+    } catch (e) {
+      return null;
+    }
+    const type = json.type;
+    const rawType = json.raw_type;
+    if (!type || type === '(unknown)' || type === '') {
+      if (type === '') {
+        // This should not happen. The Flow team believes it's an error in Flow
+        // if it does. I'm leaving the condition here because it used to happen
+        // before the switch to JSON and I'd rather log something than have the
+        // user experience regress in case I'm wrong.
+        logger.error('Received empty type hint from `flow type-at-pos`');
+      }
+      return null;
+    }
+    return {type, rawType};
+  }
+
+  async flowGetCoverage(path: NuclideUri): Promise<?FlowCoverageResult> {
+    // The coverage command doesn't actually have the required information until Flow v0.28. For
+    // earlier versions, we have to fall back on dump-types, which is slower especially in
+    // pathological cases. We can remove this entirely when we want to stop supporting versions
+    // earlier than v0.28.
+
+    const version = await this._version.getVersion();
+    // Fall back to dump types if we don't know the version
+    const useDumpTypes = version == null || semver.lte(version, '0.27.0');
+    return useDumpTypes ?
+      await this._getCoverageViaDumpTypes(path) :
+      await this._getCoverageViaCoverage(path);
+  }
+
+  async _getCoverageViaDumpTypes(path: NuclideUri): Promise<?FlowCoverageResult> {
+    const args = ['dump-types', '--json', path];
+    let result;
+    try {
+      result = await this._process.execFlow(args, {});
+    } catch (e) {
+      return null;
+    }
+    if (result == null) {
+      return null;
+    }
+    let json;
+    try {
+      json = parseJSON(args, result.stdout);
+    } catch (e) {
+      // The error is already logged in parseJSON
+      return null;
+    }
+
+    const allEntries = json;
+
+    const uncoveredEntries = allEntries.filter(item => item.type === '' || item.type === 'any');
+    const uncoveredRanges = uncoveredEntries.map(item => flowCoordsToAtomCoords(item.loc));
+
+    const uncoveredCount = uncoveredEntries.length;
+    const totalCount = allEntries.length;
+    const coveredCount = totalCount - uncoveredCount;
+    return {
+      percentage: totalCount === 0 ? 100 : coveredCount / totalCount * 100,
+      uncoveredRanges,
+    };
+  }
+
+  async _getCoverageViaCoverage(path: NuclideUri): Promise<?FlowCoverageResult> {
+    const args = ['coverage', '--json', path];
+    let result;
+    try {
+      result = await this._process.execFlow(args, {});
+    } catch (e) {
+      return null;
+    }
+    if (result == null) {
+      return null;
+    }
+    let json;
+    try {
+      json = parseJSON(args, result.stdout);
+    } catch (e) {
+      // The error is already logged in parseJSON
+      return null;
+    }
+
+    const expressions = json.expressions;
+
+    const uncoveredCount = expressions.uncovered_count;
+    const coveredCount = expressions.covered_count;
+    const totalCount = uncoveredCount + coveredCount;
+
+    const uncoveredRanges = expressions.uncovered_locs.map(flowCoordsToAtomCoords);
+
+    return {
+      percentage: totalCount === 0 ? 100 : coveredCount / totalCount * 100,
+      uncoveredRanges,
+    };
+  }
+
+  async _forceRecheck(file: string): Promise<boolean> {
+    try {
+      await this._process.execFlow(
+        ['force-recheck', file],
+        /* options */ {},
+        // Make an attempt to force a recheck, but if the server is busy don't insist.
+        /* waitsForServer */ false,
+        /* suppressErrors */ true,
+      );
+      return true;
+    } catch (e) {
+      // This command was introduced in Flow v0.23, so silently swallow errors to avoid logspam on
+      // earlier versions, until we want to break support for earlier version.
+      return false;
+    }
+  }
+
+  async _flowGetVersion(): Promise<?string> {
+    const args = ['version', '--json'];
+    let json;
+    try {
+      const result = await FlowProcess.execFlowClient(args);
+      if (result == null) {
+        return null;
+      }
+      json = parseJSON(args, result.stdout);
+    } catch (e) {
+      logger.warn(e);
+      return null;
+    }
+    return json.semver;
+  }
+
+  static async flowGetOutline(currentContents: string): Promise<?Array<FlowOutlineTree>> {
+    const options = {
+      stdin: currentContents,
+    };
+
+    const args = ['ast'];
+
+    let json;
+    try {
+      const result = await FlowProcess.execFlowClient(args, options);
+      if (result == null) {
+        return null;
+      }
+      json = parseJSON(args, result.stdout);
+    } catch (e) {
+      logger.warn(e);
+      return null;
+    }
+
+    try {
+      return astToOutline(json);
+    } catch (e) {
+      // Traversing the AST is an error-prone process and it's hard to be sure we've handled all the
+      // cases. Fail gracefully if it does not work.
+      logger.error(e);
+      return null;
+    }
+  }
+}
+
+function parseJSON(args: Array<any>, value: string): any {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    logger.error(`Invalid JSON result from flow ${args.join(' ')}. JSON:\n'${value}'.`);
+    throw e;
+  }
+}

--- a/server/src/pkg/flow-base/lib/FlowRootContainer.js
+++ b/server/src/pkg/flow-base/lib/FlowRootContainer.js
@@ -1,0 +1,98 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {Observable} from 'rxjs';
+import type {ServerStatusUpdate} from '..';
+
+import invariant from 'assert';
+import {Subject} from 'rxjs';
+
+import {findFlowConfigDir} from './FlowHelpers';
+import {FlowRoot} from './FlowRoot';
+
+export class FlowRootContainer {
+  // string rather than NuclideUri because this module will always execute at the location of the
+  // file, so it will always be a real path and cannot be prefixed with nuclide://
+  _flowRootMap: Map<string, FlowRoot>;
+
+  _flowRoot$: Subject<FlowRoot>;
+
+  _disposed: boolean;
+
+  constructor() {
+    this._disposed = false;
+    this._flowRootMap = new Map();
+
+    // No need to dispose of this subscription since we want to keep it for the entire life of this
+    // object. When this object is garbage collected the subject should be too.
+    this._flowRoot$ = new Subject();
+    this._flowRoot$.subscribe(flowRoot => {
+      this._flowRootMap.set(flowRoot.getPathToRoot(), flowRoot);
+    });
+  }
+
+  async getRootForPath(path: string): Promise<?FlowRoot> {
+    this._checkForDisposal();
+    const rootPath = await findFlowConfigDir(path);
+    console.log('rootPath', rootPath)
+    // During the await above, this may have been disposed. If so, return null to stop the current
+    // operation.
+    if (rootPath == null || this._disposed) {
+      return null;
+    }
+
+    let instance = this._flowRootMap.get(rootPath);
+    if (!instance) {
+      instance = new FlowRoot(rootPath);
+      this._flowRoot$.next(instance);
+    }
+    return instance;
+  }
+
+  async runWithRoot<T>(
+    file: string,
+    f: (instance: FlowRoot) => Promise<T>,
+  ): Promise<?T> {
+    this._checkForDisposal();
+    const instance = await this.getRootForPath(file);
+    if (instance == null) {
+      return null;
+    }
+
+    return await f(instance);
+  }
+
+  getAllRoots(): Iterable<FlowRoot> {
+    this._checkForDisposal();
+    return this._flowRootMap.values();
+  }
+
+  getServerStatusUpdates(): Observable<ServerStatusUpdate> {
+    this._checkForDisposal();
+    return this._flowRoot$.flatMap(root => {
+      const pathToRoot = root.getPathToRoot();
+      // The status update stream will be completed when a root is disposed, so there is no need to
+      // use takeUntil here to truncate the stream and release resources.
+      return root.getServerStatusUpdates().map(status => ({pathToRoot, status}));
+    });
+  }
+
+  dispose(): void {
+    this._checkForDisposal();
+    this._flowRootMap.forEach(instance => instance.dispose());
+    this._flowRootMap.clear();
+    this._disposed = true;
+  }
+
+  _checkForDisposal(): void {
+    invariant(!this._disposed, 'Method called on disposed FlowRootContainer');
+  }
+}

--- a/server/src/pkg/flow-base/lib/FlowService.js
+++ b/server/src/pkg/flow-base/lib/FlowService.js
@@ -1,0 +1,222 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {Observable} from 'rxjs';
+
+import type {NuclideUri} from '../../nuclide-remote-uri/lib/main';
+
+// Diagnostic information, returned from findDiagnostics.
+export type Diagnostics = {
+  // The location of the .flowconfig where these messages came from.
+  flowRoot: NuclideUri;
+  messages: Array<Diagnostic>;
+};
+
+/*
+ * Each error or warning can consist of any number of different messages from
+ * Flow to help explain the problem and point to different locations that may be
+ * of interest.
+ */
+export type Diagnostic = {
+  level: string;
+  messageComponents: Array<MessageComponent>;
+};
+
+export type MessageComponent = {
+  descr: string;
+  range: ?Range;
+};
+
+export type Range = {
+  file: NuclideUri;
+  start: Point;
+  end: Point;
+};
+
+export type Point = {
+  line: number;
+  column: number;
+};
+
+export type Loc = {
+  file: NuclideUri;
+  point: Point;
+};
+
+// If types are added here, make sure to also add them to FlowConstants.js. This needs to be the
+// canonical type definition so that we can use these in the service framework.
+export type ServerStatusType =
+  'failed' |
+  'unknown' |
+  'not running' |
+  'not installed' |
+  'busy' |
+  'init' |
+  'ready';
+
+export type ServerStatusUpdate = {
+  pathToRoot: NuclideUri;
+  status: ServerStatusType;
+};
+
+export type FlowOutlineTree = {
+  tokenizedText: TokenizedText;
+  representativeName?: string;
+  children: Array<FlowOutlineTree>;
+  startPosition: Point;
+  endPosition: Point;
+};
+
+// The origin of this type is at nuclide-tokenized-text/lib/main.js
+// When updating update both locations!
+export type TokenKind = 'keyword'
+  | 'class-name'
+  | 'constructor'
+  | 'method'
+  | 'param'
+  | 'string'
+  | 'whitespace'
+  | 'plain'
+  | 'type'
+  ;
+
+// The origin of this type is at nuclide-tokenized-text/lib/main.js
+// When updating update both locations!
+export type TextToken = {
+  kind: TokenKind;
+  value: string;
+};
+
+// The origin of this type is at nuclide-tokenized-text/lib/main.js
+// When updating update both locations!
+export type TokenizedText = Array<TextToken>;
+
+export type FlowCoverageResult = {
+  percentage: number;
+  uncoveredRanges: Array<{
+    start: Point;
+    end: Point;
+  }>;
+};
+
+import {FlowRoot} from './FlowRoot';
+
+import {FlowRootContainer} from './FlowRootContainer';
+let rootContainer: ?FlowRootContainer = null;
+
+function getRootContainer(): FlowRootContainer {
+  if (rootContainer == null) {
+    rootContainer = new FlowRootContainer();
+  }
+  return rootContainer;
+}
+
+export function dispose(): void {
+  if (rootContainer != null) {
+    rootContainer.dispose();
+    rootContainer = null;
+  }
+}
+
+export function getServerStatusUpdates(): Observable<ServerStatusUpdate> {
+  return getRootContainer().getServerStatusUpdates();
+}
+
+export function flowFindDefinition(
+  file: NuclideUri,
+  currentContents: string,
+  line: number,
+  column: number,
+): Promise<?Loc> {
+  return getRootContainer().runWithRoot(
+    file,
+    root => root.flowFindDefinition(
+      file,
+      currentContents,
+      line,
+      column,
+    )
+  );
+}
+
+export function flowFindDiagnostics(
+  file: NuclideUri,
+  currentContents: ?string,
+): Promise<?Diagnostics> {
+  return getRootContainer().runWithRoot(
+    file,
+    root => root.flowFindDiagnostics(
+      file,
+      currentContents,
+    )
+  );
+}
+
+export function flowGetAutocompleteSuggestions(
+  file: NuclideUri,
+  currentContents: string,
+  line: number,
+  column: number,
+  prefix: string,
+  activatedManually: boolean,
+): Promise<any> {
+  return getRootContainer().runWithRoot(
+    file,
+    root => root.flowGetAutocompleteSuggestions(
+      file,
+      currentContents,
+      line,
+      column,
+      prefix,
+      activatedManually,
+    )
+  );
+}
+
+export async function flowGetType(
+  file: NuclideUri,
+  currentContents: string,
+  line: number,
+  column: number,
+  includeRawType: boolean,
+): Promise<?{type: string; rawType: ?string}> {
+  return getRootContainer().runWithRoot(
+    file,
+    root => root.flowGetType(
+      file,
+      currentContents,
+      line,
+      column,
+      includeRawType,
+    )
+  );
+}
+
+export async function flowGetCoverage(
+  file: NuclideUri,
+): Promise<?FlowCoverageResult> {
+  return getRootContainer().runWithRoot(
+    file,
+    root => root.flowGetCoverage(file),
+  );
+}
+
+export function flowGetOutline(
+  currentContents: string,
+): Promise<?Array<FlowOutlineTree>> {
+  return FlowRoot.flowGetOutline(currentContents);
+}
+
+export function allowServerRestart(): void {
+  for (const root of getRootContainer().getAllRoots()) {
+    root.allowServerRestart();
+  }
+}

--- a/server/src/pkg/flow-base/lib/FlowVersion.js
+++ b/server/src/pkg/flow-base/lib/FlowVersion.js
@@ -1,0 +1,59 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import {VERSION_TIMEOUT_MS} from './FlowConstants';
+
+type VersionWithTimestamp = {
+  version: ?string;
+  receivedTime: number;
+};
+
+/*
+ * Queries Flow for its version and caches the results. The version is a best guess: it is not 100%
+ * guaranteed to be reliable due to caching, but will nearly always be correct.
+ */
+export class FlowVersion {
+  _lastVersion: ?VersionWithTimestamp;
+
+  _versionFn: () => Promise<?string>;
+
+  constructor(
+    versionFn: () => Promise<?string>,
+  ) {
+    this._versionFn = versionFn;
+    this._lastVersion = null;
+  }
+
+  invalidateVersion(): void {
+    this._lastVersion = null;
+  }
+
+  async getVersion(): Promise<?string> {
+    const lastVersion = this._lastVersion;
+    if (lastVersion == null) {
+      return await this._queryAndSetVersion();
+    }
+    const msSinceReceived = Date.now() - lastVersion.receivedTime;
+    if (msSinceReceived >= VERSION_TIMEOUT_MS) {
+      return await this._queryAndSetVersion();
+    }
+    return lastVersion.version;
+  }
+
+  async _queryAndSetVersion(): Promise<?string> {
+    const version = await this._versionFn();
+    this._lastVersion = {
+      version,
+      receivedTime: Date.now(),
+    };
+    return version;
+  }
+}

--- a/server/src/pkg/flow-base/lib/astToOutline.js
+++ b/server/src/pkg/flow-base/lib/astToOutline.js
@@ -1,0 +1,379 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {FlowOutlineTree, Point} from '..';
+import {arrayCompact} from '../../commons-node/collection';
+
+import type {TokenizedText} from '../../nuclide-tokenized-text/lib/main';
+import {
+  keyword,
+  className,
+  method,
+  param,
+  string,
+  whitespace,
+  plain,
+  // This is to work around a Flow parser bug.
+  type as type,
+} from '../../nuclide-tokenized-text/lib/main';
+
+import invariant from 'assert';
+
+type Extent = {
+  startPosition: Point;
+  endPosition: Point;
+};
+
+export function astToOutline(ast: any): Array<FlowOutlineTree> {
+  return itemsToTrees(ast.body);
+}
+
+function itemsToTrees(items: Array<any>): Array<FlowOutlineTree> {
+  return arrayCompact(items.map(itemToTree));
+}
+
+function itemToTree(item: any): ?FlowOutlineTree {
+  if (item == null) {
+    return null;
+  }
+  const extent = getExtent(item);
+  switch (item.type) {
+    case 'FunctionDeclaration':
+      return {
+        tokenizedText: [
+          keyword('function'),
+          whitespace(' '),
+          method(item.id.name),
+          plain('('),
+          ...paramsTokenizedText(item.params),
+          plain(')'),
+        ],
+        representativeName: item.id.name,
+        children: [],
+        ...extent,
+      };
+    case 'ClassDeclaration':
+      return {
+        tokenizedText: [
+          keyword('class'),
+          whitespace(' '),
+          className(item.id.name),
+        ],
+        representativeName: item.id.name,
+        children: itemsToTrees(item.body.body),
+        ...extent,
+      };
+    case 'ClassProperty':
+      let paramTokens = [];
+      if (item.value && item.value.type === 'ArrowFunctionExpression') {
+        paramTokens = [
+          plain('('),
+          ...paramsTokenizedText(item.value.params),
+          plain(')'),
+        ];
+      }
+      return {
+        tokenizedText: [
+          method(item.key.name),
+          plain('='),
+          ...paramTokens,
+        ],
+        representativeName: item.key.name,
+        children: [],
+        ...extent,
+      };
+    case 'MethodDefinition':
+      return {
+        tokenizedText: [
+          method(item.key.name),
+          plain('('),
+          ...paramsTokenizedText(item.value.params),
+          plain(')'),
+        ],
+        representativeName: item.key.name,
+        children: [],
+        ...extent,
+      };
+    case 'ExportDeclaration':
+      const tree = itemToTree(item.declaration);
+      if (tree == null) {
+        return null;
+      }
+      return {
+        tokenizedText: [
+          keyword('export'),
+          whitespace(' '),
+          ...tree.tokenizedText,
+        ],
+        representativeName: tree.representativeName,
+        children: tree.children,
+        ...extent,
+      };
+    case 'ExpressionStatement':
+      return topLevelExpressionOutline(item);
+    case 'TypeAlias':
+      return typeAliasOutline(item);
+    default:
+      return null;
+  }
+}
+
+function paramsTokenizedText(params: Array<any>): TokenizedText {
+  const textElements = [];
+  params.forEach((p, index) => {
+    switch (p.type) {
+      case 'Identifier':
+        textElements.push(param(p.name));
+        break;
+      case 'ObjectPattern':
+        textElements.push(plain('{'));
+        textElements.push(...paramsTokenizedText(p.properties.map(obj => obj.key)));
+        textElements.push(plain('}'));
+        break;
+      case 'ArrayPattern':
+        textElements.push(plain('['));
+        textElements.push(...paramsTokenizedText(p.elements));
+        textElements.push(plain(']'));
+        break;
+      default:
+        throw new Error(`encountered unexpected argument type ${p.type}`);
+    }
+    if (index < params.length - 1) {
+      textElements.push(plain(','));
+      textElements.push(whitespace(' '));
+    }
+  });
+
+  return textElements;
+}
+
+function getExtent(item: any): Extent {
+  return {
+    startPosition: {
+      // It definitely makes sense that the lines we get are 1-based and the columns are
+      // 0-based... convert to 0-based all around.
+      line: item.loc.start.line - 1,
+      column: item.loc.start.column,
+    },
+    endPosition: {
+      line: item.loc.end.line - 1,
+      column: item.loc.end.column,
+    },
+  };
+}
+
+function typeAliasOutline(typeAliasExpression: any): FlowOutlineTree {
+  invariant(typeAliasExpression.type === 'TypeAlias');
+  const name = typeAliasExpression.id.name;
+  return {
+    tokenizedText: [
+      keyword('type'),
+      whitespace(' '),
+      type(name),
+    ],
+    representativeName: name,
+    children: [],
+    ...getExtent(typeAliasExpression),
+  };
+}
+
+function topLevelExpressionOutline(expressionStatement: any): ?FlowOutlineTree {
+  switch (expressionStatement.expression.type) {
+    case 'CallExpression':
+      return specOutline(expressionStatement, /* describeOnly */ true);
+    case 'AssignmentExpression':
+      return moduleExportsOutline(expressionStatement.expression);
+    default:
+      return null;
+  }
+}
+
+function moduleExportsOutline(assignmentStatement: any): ?FlowOutlineTree {
+  invariant(assignmentStatement.type === 'AssignmentExpression');
+
+  const left = assignmentStatement.left;
+  if (!isModuleExports(left)) {
+    return null;
+  }
+
+  const right = assignmentStatement.right;
+  if (right.type !== 'ObjectExpression') {
+    return null;
+  }
+  const properties: Array<Object> = right.properties;
+  return {
+    tokenizedText: [plain('module.exports')],
+    children: arrayCompact(properties.map(moduleExportsPropertyOutline)),
+    ...getExtent(assignmentStatement),
+  };
+}
+
+function isModuleExports(left: Object): boolean {
+  return left.type === 'MemberExpression' &&
+    left.object.type === 'Identifier' &&
+    left.object.name === 'module' &&
+    left.property.type === 'Identifier' &&
+    left.property.name === 'exports';
+}
+
+function moduleExportsPropertyOutline(property: any): ?FlowOutlineTree {
+  invariant(property.type === 'Property');
+  if (property.key.type !== 'Identifier') {
+    return null;
+  }
+  const propName = property.key.name;
+
+  if (property.shorthand) {
+    // This happens when the shorthand `{ foo }` is used for `{ foo: foo }`
+    return {
+      tokenizedText: [
+        string(propName),
+      ],
+      representativeName: propName,
+      children: [],
+      ...getExtent(property),
+    };
+  }
+
+  if (property.value.type === 'FunctionExpression' ||
+    property.value.type === 'ArrowFunctionExpression'
+  ) {
+    return {
+      tokenizedText: [
+        method(propName),
+        plain('('),
+        ...paramsTokenizedText(property.value.params),
+        plain(')'),
+      ],
+      representativeName: propName,
+      children: [],
+      ...getExtent(property),
+    };
+  }
+
+  return {
+    tokenizedText: [
+      string(propName),
+      plain(':'),
+    ],
+    representativeName: propName,
+    children: [],
+    ...getExtent(property),
+  };
+}
+
+function specOutline(expressionStatement: any, describeOnly: boolean = false): ?FlowOutlineTree {
+  const expression = expressionStatement.expression;
+  if (expression.type !== 'CallExpression') {
+    return null;
+  }
+  const functionName = getFunctionName(expression.callee);
+  if (functionName == null) {
+    return null;
+  }
+  if (!isDescribe(functionName)) {
+    if (describeOnly || !isIt(functionName)) {
+      return null;
+    }
+  }
+  const description = getStringLiteralValue(expression.arguments[0]);
+  const specBody = getFunctionBody(expression.arguments[1]);
+  if (description == null || specBody == null) {
+    return null;
+  }
+  let children;
+  if (isIt(functionName)) {
+    children = [];
+  } else {
+    children = arrayCompact(
+      specBody
+      .filter(item => item.type === 'ExpressionStatement')
+      .map(item => specOutline(item)));
+  }
+  return {
+    tokenizedText: [
+      method(functionName),
+      whitespace(' '),
+      string(description),
+    ],
+    representativeName: description,
+    children,
+    ...getExtent(expressionStatement),
+  };
+}
+
+// Return the function name as written as a string. Intended to stringify patterns like `describe`
+// and `describe.only` even though `describe.only` is a MemberExpression rather than an Identifier.
+function getFunctionName(callee: any): ?string {
+  switch (callee.type) {
+    case 'Identifier':
+      return callee.name;
+    case 'MemberExpression':
+      if (callee.object.type !== 'Identifier' || callee.property.type !== 'Identifier') {
+        return null;
+      }
+      return `${callee.object.name}.${callee.property.name}`;
+    default:
+      return null;
+  }
+}
+
+function isDescribe(functionName: string): boolean {
+  switch (functionName) {
+    case 'describe':
+    case 'fdescribe':
+    case 'ddescribe':
+    case 'xdescribe':
+    case 'describe.only':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isIt(functionName: string): boolean {
+  switch (functionName) {
+    case 'it':
+    case 'fit':
+    case 'iit':
+    case 'pit':
+    case 'xit':
+    case 'it.only':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** If the given AST Node is a string literal, return its literal value. Otherwise return null */
+function getStringLiteralValue(literal: ?any): ?string {
+  if (literal == null) {
+    return null;
+  }
+  if (literal.type !== 'Literal') {
+    return null;
+  }
+  const value = literal.value;
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return value;
+}
+
+function getFunctionBody(fn: ?any): ?Array<any> {
+  if (fn == null) {
+    return null;
+  }
+  if (fn.type !== 'ArrowFunctionExpression' && fn.type !== 'FunctionExpression') {
+    return null;
+  }
+  return fn.body.body;
+}

--- a/server/src/pkg/flow-base/lib/diagnosticsParser.js
+++ b/server/src/pkg/flow-base/lib/diagnosticsParser.js
@@ -1,0 +1,163 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {
+  Diagnostics,
+  Diagnostic,
+  MessageComponent,
+  Range,
+} from '..';
+
+import type {
+  OldFlowStatusOutput,
+  OldFlowStatusError,
+  OldFlowStatusErrorMessageComponent,
+  OldBaseFlowStatusErrorMessageComponent,
+  NewFlowStatusOutput,
+  NewFlowStatusError,
+  NewFlowStatusErrorMessageComponent,
+  FlowLoc,
+} from './flowOutputTypes';
+
+export function flowStatusOutputToDiagnostics(
+  root: string,
+  statusOutput: Object,
+): Diagnostics {
+  if (statusOutput.flowVersion != null) {
+    return newFlowStatusOutputToDiagnostics(root, statusOutput);
+  } else {
+    return oldFlowStatusOutputToDiagnostics(root, statusOutput);
+  }
+}
+
+export function oldFlowStatusOutputToDiagnostics(
+  root: string,
+  statusOutput: OldFlowStatusOutput,
+): Diagnostics {
+  const errors: Array<OldFlowStatusError> = statusOutput.errors;
+  const messages: Array<Diagnostic> = errors.map((flowStatusError: OldFlowStatusError) => {
+    const flowMessageComponents: Array<OldFlowStatusErrorMessageComponent> =
+      flowStatusError.message;
+    const level = flowMessageComponents[0].level;
+
+    const messageComponents: Array<MessageComponent> =
+      flowMessageComponents.map(flowMessageComponentToMessageComponent);
+    const operation = flowStatusError.operation;
+    if (operation != null) {
+      // The operation field provides additional context. I don't fully understand the motivation
+      // behind separating it out, but prepending it with 'See also: ' and adding it to the end of
+      // the messages is what the Flow team recommended.
+      const operationComponent = flowMessageComponentToMessageComponent(operation);
+      operationComponent.descr = 'See also: ' + operationComponent.descr;
+      messageComponents.push(operationComponent);
+    }
+    return {
+      level,
+      messageComponents,
+    };
+  });
+
+  return {
+    flowRoot: root,
+    messages,
+  };
+}
+
+function flowMessageComponentToMessageComponent(
+  component: OldBaseFlowStatusErrorMessageComponent,
+): MessageComponent {
+  const path = component.path;
+  let range = null;
+
+  // Flow returns the empty string instead of null when there is no relevant path. The upcoming
+  // format changes described elsewhere in this file fix the issue, but for now we must still work
+  // around it.
+  if (path != null && path !== '') {
+    range = {
+      file: path,
+      start: {
+        line: component.line,
+        column: component.start,
+      },
+      end: {
+        line: component.endline,
+        column: component.end,
+      },
+    };
+  }
+  return {
+    descr: component.descr,
+    range,
+  };
+}
+
+export function newFlowStatusOutputToDiagnostics(
+  root: string,
+  statusOutput: NewFlowStatusOutput,
+): Diagnostics {
+  const errors: Array<NewFlowStatusError> = statusOutput.errors;
+  const messages: Array<Diagnostic> = errors.map((flowStatusError: NewFlowStatusError) => {
+    const flowMessageComponents: Array<NewFlowStatusErrorMessageComponent> =
+      flowStatusError.message;
+    const level = flowStatusError.level;
+
+    const messageComponents: Array<MessageComponent> =
+      flowMessageComponents.map(newFlowMessageComponentToMessageComponent);
+    const operation = flowStatusError.operation;
+    if (operation != null) {
+      const operationComponent = newFlowMessageComponentToMessageComponent(operation);
+      operationComponent.descr = 'See also: ' + operationComponent.descr;
+      messageComponents.push(operationComponent);
+    }
+    const extra = flowStatusError.extra;
+    if (extra != null) {
+      const flatExtra = [].concat(...extra.map(({message}) => message));
+      messageComponents.push(...flatExtra.map(newFlowMessageComponentToMessageComponent));
+    }
+
+    return {
+      level,
+      messageComponents,
+    };
+  });
+
+  return {
+    flowRoot: root,
+    messages,
+  };
+}
+
+function newFlowMessageComponentToMessageComponent(
+  component: NewFlowStatusErrorMessageComponent,
+): MessageComponent {
+  return {
+    descr: component.descr,
+    range: maybeFlowLocToRange(component.loc),
+  };
+}
+
+function maybeFlowLocToRange(loc: ?FlowLoc): ?Range {
+  return loc == null ? null : flowLocToRange(loc);
+}
+
+function flowLocToRange(loc: FlowLoc): Range {
+  return {
+    file: loc.source,
+    start: {
+      line: loc.start.line,
+      column: loc.start.column,
+    },
+    end: {
+      line: loc.end.line,
+      column: loc.end.column,
+    },
+  };
+}

--- a/server/src/pkg/flow-base/lib/flowOutputTypes.js
+++ b/server/src/pkg/flow-base/lib/flowOutputTypes.js
@@ -1,0 +1,88 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+/* FLOW STATUS */
+
+// Types for the old `flow status` output -- v0.22 and below
+
+export type OldFlowStatusOutput = {
+  passed: boolean;
+  // This is not actually the Flow version; instead it is a build ID or something.
+  version?: string;
+  errors: Array<OldFlowStatusError>;
+};
+
+export type OldFlowStatusError = {
+  kind: string;
+  operation?: OldFlowStatusErrorOperation;
+  message: Array<OldFlowStatusErrorMessageComponent>;
+};
+
+export type OldBaseFlowStatusErrorMessageComponent = {
+  // If there is no path component, this is the empty string. We should make it null instead, in
+  // that case (t8644340)
+  path: string;
+  descr: string;
+  line: number;
+  start: number;
+  end: number;
+  endline: number;
+};
+
+export type OldFlowStatusErrorMessageComponent = OldBaseFlowStatusErrorMessageComponent & {
+  level: 'error' | 'warning';
+};
+
+// Same as FlowStatusErrorMessageComponent, except without the 'level' field.
+export type OldFlowStatusErrorOperation = OldBaseFlowStatusErrorMessageComponent;
+
+// New types for `flow status` v0.23.0 (or possibly v0.24.0, it has yet to be finalized)
+
+export type NewFlowStatusOutput = {
+  passed: boolean;
+  flowVersion: string;
+  errors: Array<NewFlowStatusError>;
+};
+
+export type NewFlowStatusError = {
+  level: 'error' | 'warning';
+  // e.g. parse, infer, maybe others?
+  kind: string;
+  message: Array<NewFlowStatusErrorMessageComponent>;
+  operation?: NewFlowStatusErrorMessageComponent;
+  extra?: Array<{
+    message: Array<NewFlowStatusErrorMessageComponent>;
+  }>;
+};
+
+export type NewFlowStatusErrorMessageComponent = {
+  descr: string;
+  loc?: FlowLoc;
+  // The old path, line, etc. fields also currently exist here, but they are deprecated in favor of
+  // `loc`.
+};
+
+export type FlowLoc = {
+  // file path
+  source: string;
+  start: FlowPoint;
+  end: FlowPoint;
+};
+
+export type FlowLocNoSource = {
+  start: FlowPoint;
+  end: FlowPoint;
+};
+
+export type FlowPoint = {
+  column: number;
+  line: number;
+};

--- a/server/src/pkg/flow-base/package.json
+++ b/server/src/pkg/flow-base/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuclide-flow-base",
+  "repository": "https://github.com/facebook/nuclide",
+  "main": "./lib/FlowService.js",
+  "version": "0.0.0",
+  "description": "Provides base support for flow utilities.",
+  "nuclide": {
+    "packageType": "Node",
+    "testRunner": "npm"
+  },
+  "scripts": {
+    "test": "node ../nuclide-jasmine/bin/jasmine-node-transpiled spec"
+  }
+}

--- a/server/src/pkg/nuclide-logging/README.md
+++ b/server/src/pkg/nuclide-logging/README.md
@@ -1,0 +1,24 @@
+# nuclide-logging
+
+A Nuclide feature designed for logging on both Nuclide client and Nuclide server. It is based on
+[log4js](https://www.npmjs.com/package/log4js) with the ability to lazy initialize and update config
+after initialized.
+
+## Usage
+
+```js
+var logger = require('nuclide/pkg/nuclide-logging/lib/main').getLogger();
+
+logger.debug(...);
+logger.error(...);
+```
+
+## Update Configuration
+
+The logger will use the default configuration in `./lib/config.js` to initialize nested log4js logger. However, one could update its configuration by calling
+```js
+var logger1 = require('nuclide/pkg/nuclide-logging/lib/main').getLogger();
+require('nuclide-logging').updateConfig(config, option);
+// logger1's configuration is updated as well.
+```
+Note this will also update the configuration of logger who has already been created.

--- a/server/src/pkg/nuclide-logging/lib/config.js
+++ b/server/src/pkg/nuclide-logging/lib/config.js
@@ -1,0 +1,112 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {LoggingAppender} from './types';
+import ScribeProcess from '../../commons-node/ScribeProcess';
+import {isRunningInTest, isRunningInClient} from '../../commons-node/system-info';
+import fsPromise from '../../commons-node/fsPromise';
+import userInfo from '../../commons-node/userInfo';
+
+import os from 'os';
+import nuclideUri from '../../nuclide-remote-uri/lib/main';
+
+const LOG_DIRECTORY = nuclideUri.join(os.tmpdir(), `/nuclide-${userInfo().username}-logs`);
+const LOG_FILE_PATH = nuclideUri.join(LOG_DIRECTORY, 'nuclide.log');
+
+let logDirectoryInitialized = false;
+const scribeAppenderPath = nuclideUri.join(__dirname, '../fb/scribeAppender.js');
+
+const LOG4JS_DATE_FORMAT = '-yyyy-MM-dd';
+
+async function getServerLogAppenderConfig(): Promise<?Object> {
+  // Skip config scribe_cat logger if
+  // 1) running in test environment
+  // 2) or running in Atom client
+  // 3) or running in open sourced version of nuclide
+  // 4) or the scribe_cat command is missing.
+  if (isRunningInTest() ||
+      isRunningInClient() ||
+      !(await fsPromise.exists(scribeAppenderPath)) ||
+      !(await ScribeProcess.isScribeCatOnPath())) {
+    return null;
+  }
+
+  return {
+    type: 'logLevelFilter',
+    level: 'DEBUG',
+    appender: {
+      type: scribeAppenderPath,
+      scribeCategory: 'errorlog_arsenal',
+    },
+  };
+}
+
+/**
+ * @return The absolute path to the log file for the specified date.
+ */
+function getPathToLogFileForDate(targetDate: Date): string {
+  const log4jsFormatter = require('log4js/lib/date_format').asString;
+  return LOG_FILE_PATH + log4jsFormatter(LOG4JS_DATE_FORMAT, targetDate);
+}
+
+/**
+ * @return The absolute path to the log file for today.
+ */
+function getPathToLogFileForToday(): string {
+  return getPathToLogFileForDate(new Date());
+}
+
+module.exports = {
+  async getDefaultConfig(): Promise<LoggingAppender> {
+
+    if (!logDirectoryInitialized) {
+      await fsPromise.mkdirp(LOG_DIRECTORY);
+      logDirectoryInitialized = true;
+    }
+
+    const config = {
+      appenders: [
+        {
+          type: 'logLevelFilter',
+          level: 'INFO',
+          appender: {
+            type: nuclideUri.join(__dirname, './consoleAppender'),
+          },
+        },
+        {
+          type: 'dateFile',
+          alwaysIncludePattern: true,
+          absolute: true,
+          filename: LOG_FILE_PATH,
+          pattern: LOG4JS_DATE_FORMAT,
+          layout: {
+            type: 'pattern',
+            // Format log in following pattern:
+            // yyyy-MM-dd HH:mm:ss.mil $Level (pid:$pid) $categroy - $message.
+            pattern: `%d{ISO8601} %p (pid:${process.pid}) %c - %m`,
+          },
+        },
+      ],
+    };
+
+    const serverLogAppenderConfig = await getServerLogAppenderConfig();
+    if (serverLogAppenderConfig) {
+      config.appenders.push(serverLogAppenderConfig);
+    }
+
+    return config;
+  },
+  getPathToLogFileForToday,
+  LOG_FILE_PATH,
+  __test__: {
+    getPathToLogFileForDate,
+  },
+};

--- a/server/src/pkg/nuclide-logging/lib/consoleAppender.js
+++ b/server/src/pkg/nuclide-logging/lib/consoleAppender.js
@@ -1,0 +1,53 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import util from 'util';
+
+function layout(loggingEvent: any): Array<any> {
+  const eventInfo = util.format(
+    '[%s] [%s] %s - ',
+    loggingEvent.startTime.toISOString(),
+    loggingEvent.level,
+    loggingEvent.categoryName);
+
+  const data = loggingEvent.data.slice();
+
+  // Since console.log support string format as first parameter, we should preserve this behavior
+  // by concating eventInfo with first parameter if it is string.
+  if (data.length > 0 && typeof data[0] === 'string') {
+    data[0] = eventInfo + data[0];
+  } else {
+    data.unshift(eventInfo);
+  }
+  return data;
+}
+
+/**
+ * Comparing to log4js's console appender(https://fburl.com/69861669), you can expand and explore
+ * the object in console logged by this Appender.
+ */
+function consoleAppender(): (loggingEvent: any) => void {
+  return loggingEvent => {
+    console.log.apply(console, layout(loggingEvent)); // eslint-disable-line no-console
+
+    // Also support outputing information into a VS Code console,
+    // it is only string based, so we only take the first string
+    if (global.flowOutputChannel) {
+      const message = layout(loggingEvent)[0]
+      global.flowOutputChannel.appendLine(message.replace("nuclide -", "flow -"))
+    }
+  };
+}
+
+module.exports = {
+  appender: consoleAppender,
+  configure: consoleAppender,
+};

--- a/server/src/pkg/nuclide-logging/lib/main.js
+++ b/server/src/pkg/nuclide-logging/lib/main.js
@@ -1,0 +1,183 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+/**
+ * This designed for logging on both Nuclide client and Nuclide server. It is based on [log4js]
+ * (https://www.npmjs.com/package/log4js) with the ability to lazy initialize and update config
+ * after initialized.
+ * To make sure we only have one instance of log4js logger initialized globally, we save the logger
+ * to `global` object.
+ */
+import addPrepareStackTraceHook from './stacktrace';
+import invariant from 'assert';
+import singleton from '../../commons-node/singleton';
+
+import type {LogLevel} from './rpc-types';
+import type {Logger} from './types';
+
+/* Listed in order of severity. */
+type Level = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+const DEFAULT_LOGGER_CATEGORY = 'nuclide';
+const INITIAL_UPDATE_CONFIG_KEY = '_initial_update_config_key_';
+
+function getCategory(category: ?string): string {
+  return category ? category : DEFAULT_LOGGER_CATEGORY;
+}
+
+export function flushLogsAndExit(exitCode: number): void {
+  const log4js = require('log4js');
+  log4js.shutdown(() => process.exit(exitCode));
+}
+
+export function flushLogsAndAbort(): void {
+  const log4js = require('log4js');
+  log4js.shutdown(() => process.abort());
+}
+
+/**
+ * Get log4js logger instance which is also singleton per category.
+ * log4js.getLogger() API internally should already provide singleton per category guarantee
+ * see https://github.com/nomiddlename/log4js-node/blob/master/lib/log4js.js#L120 for details.
+ */
+function getLog4jsLogger(category: string): Object {
+  const log4js = require('log4js');
+  return log4js.getLogger(category);
+}
+
+export function updateConfig(config: any, options: any): void {
+  // update config takes affect global to all existing and future loggers.
+  const log4js = require('log4js');
+  log4js.configure(config, options);
+}
+
+// Create a lazy logger that will not initialize the underlying log4js logger until
+// `lazyLogger.$level(...)` is called. This way, another package could require nuclide-logging
+// during activation without worrying about introducing a significant startup cost.
+function createLazyLogger(category: string): Logger {
+  function createLazyLoggerMethod(level: Level): (...args: Array<any>) => mixed {
+    return function(...args: Array<any>) {
+      const logger = getLog4jsLogger(category);
+      invariant(logger);
+      logger[level].apply(logger, args);
+    };
+  }
+
+  function setLoggerLevelHelper(level: string): void {
+    const logger = getLog4jsLogger(category);
+    invariant(logger);
+    logger.setLevel(level);
+  }
+
+  function isLevelEnabledHelper(level: string): void {
+    const logger = getLog4jsLogger(category);
+    invariant(logger);
+    return logger.isLevelEnabled(level);
+  }
+
+  return {
+    debug: createLazyLoggerMethod('debug'),
+    error: createLazyLoggerMethod('error'),
+    fatal: createLazyLoggerMethod('fatal'),
+    info: createLazyLoggerMethod('info'),
+    trace: createLazyLoggerMethod('trace'),
+    warn: createLazyLoggerMethod('warn'),
+    isLevelEnabled: isLevelEnabledHelper,
+    setLevel: setLoggerLevelHelper,
+  };
+}
+
+/**
+ * Push initial default config to log4js.
+ * Execute only once.
+ */
+export function initialUpdateConfig(): Promise<void> {
+  return singleton.get(
+    INITIAL_UPDATE_CONFIG_KEY,
+    async () => {
+      const defaultConfig = await require('./config').getDefaultConfig();
+      updateConfig(defaultConfig);
+    });
+}
+
+// Get Logger instance which is singleton per logger category.
+export function getLogger(category: ?string): Logger {
+  addPrepareStackTraceHook();
+  initialUpdateConfig();
+
+  const loggerCategory = getCategory(category);
+  return singleton.get(
+    loggerCategory,
+    () => {
+      return createLazyLogger(loggerCategory);
+    },
+  );
+}
+
+export type CategoryLogger = {
+  log(message: string): void;
+  logTrace(message: string): void;
+  logInfo(message: string): void;
+  logError(message: string): void;
+  logErrorAndThrow(message: string): void;
+  setLogLevel(level: LogLevel): void;
+};
+
+// Utility function that returns a wrapper logger for input category.
+export function getCategoryLogger(category: string): CategoryLogger {
+  function setLogLevel(level: LogLevel): void {
+    getLogger(category).setLevel(level);
+  }
+
+  function logHelper(level: string, message: string): void {
+    const logger = getLogger(category);
+    // isLevelEnabled() is required to reduce the amount of logging to
+    // log4js which greatly improves performance.
+    if (logger.isLevelEnabled(level)) {
+      logger[level](message);
+    }
+  }
+
+  function logTrace(message: string): void {
+    logHelper('trace', message);
+  }
+
+  function log(message: string): void {
+    logHelper('debug', message);
+  }
+
+  function logInfo(message: string): void {
+    logHelper('info', message);
+  }
+
+  function logError(message: string): void {
+    logHelper('error', message);
+  }
+
+  function logErrorAndThrow(message: string): void {
+    logError(message);
+    logError(new Error().stack);
+    throw new Error(message);
+  }
+
+  return {
+    log,
+    logTrace,
+    logInfo,
+    logError,
+    logErrorAndThrow,
+    setLogLevel,
+  };
+}
+
+export function getPathToLogFileForToday(): string {
+  return require('./config').getPathToLogFileForToday();
+}

--- a/server/src/pkg/nuclide-logging/lib/rpc-types.js
+++ b/server/src/pkg/nuclide-logging/lib/rpc-types.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type LogLevel =
+  'ALL' |
+  'TRACE' |
+  'DEBUG' |
+  'INFO' |
+  'WARN' |
+  'ERROR' |
+  'FATAL' |
+  'OFF';

--- a/server/src/pkg/nuclide-logging/lib/stacktrace.js
+++ b/server/src/pkg/nuclide-logging/lib/stacktrace.js
@@ -1,0 +1,124 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import type {node$CallSite} from './types';
+import singleton from '../../commons-node/singleton';
+
+type PrepareStackTraceFunction = (error: Error, frames: Array<node$CallSite>) => any;
+
+const PREPARE_STACK_TRACE_HOOKED_KEY = '_nuclide_error_stack_trace_hooked';
+
+let hookedPrepareStackTrace: ?PrepareStackTraceFunction;
+
+/**
+ * v8 provided a way to customize Error stacktrace generation by overwriting
+ * Error.prepareStackTrace (https://code.google.com/p/v8/wiki/JavaScriptStackTraceApi).
+ * Here we added a hook to Error.prepareStackTrace to achieve following goals:
+ *  1) Whenever `error.stack` is called, error.stackTrace will be generated.
+ *  2) Other module's customization to Error.prepareStackTrace, no matter before or after the hook
+ *     is added, will still work as expected.
+ * In this way, other module could still overwrite Error.prepareStackTrace to customize stacktrace.
+ * This is required as Atom's builtin coffeescript package need to show coffeescript stacktrace by
+ * customize Error.prepareStackTrace.
+ */
+export default function addPrepareStackTraceHook(): void {
+  singleton.get(
+    PREPARE_STACK_TRACE_HOOKED_KEY,
+    () => {
+      hookedPrepareStackTrace = createHookedPrepareStackTrace(Error.prepareStackTrace
+        || defaultPrepareStackTrace);
+
+      // Hook Error.prepareStackTrace by leveraging get/set accessor. In this way, writing to
+      // Error.prepareStackTrace will put the new prepareStackTrace functions in a wrapper that
+      // calls the hook.
+      // $FlowIssue
+      Object.defineProperty(Error, 'prepareStackTrace', {
+        get() {
+          return hookedPrepareStackTrace;
+        },
+        set(newValue) {
+          hookedPrepareStackTrace = createHookedPrepareStackTrace(newValue
+            || defaultPrepareStackTrace);
+        },
+        enumerable: false,
+        configurable: true,
+      });
+
+      // TODO (chenshen) t8789330.
+      // Atom added getRawStack to Error.prototype to get Error's structured stacktrace
+      // (https://github.com/atom/grim/blob/master/src/grim.coffee#L43). However, this
+      // doesn't work well with our customization of stacktrace. So here we temporarily
+      // walk around this by following hack, until https://github.com/atom/atom/issues/9641
+      // get addressed.
+      /* eslint-disable no-extend-native */
+      /* $FlowFixMe */
+      Error.prototype.getRawStack = null;
+      /* eslint-enable no-extend-native */
+      return true;
+    },
+  );
+}
+
+/**
+ * Create a wrapper that calls to structuredStackTraceHook first, then return the result of
+ * prepareStackTrace.
+ */
+function createHookedPrepareStackTrace(
+  prepareStackTrace: PrepareStackTraceFunction,
+): PrepareStackTraceFunction {
+  // If the prepareStackTrace is already been hooked, just return it.
+  if (prepareStackTrace.name === 'nuclideHookedPrepareStackTrace') {
+    return prepareStackTrace;
+  }
+
+  const hookedFunction = function nuclideHookedPrepareStackTrace(
+    error: Error,
+    frames: Array<node$CallSite>,
+  ): any {
+    structuredStackTraceHook(error, frames);
+    return prepareStackTrace(error, frames);
+  };
+
+  return hookedFunction;
+}
+
+function structuredStackTraceHook(error: Error, frames: Array<node$CallSite>): void {
+  // $FlowFixMe
+  error.stackTrace = frames.map(frame => {
+    return {
+      functionName: frame.getFunctionName(),
+      methodName: frame.getMethodName(),
+      fileName: frame.getFileName(),
+      lineNumber: frame.getLineNumber(),
+      columnNumber: frame.getColumnNumber(),
+      evalOrigin: frame.getEvalOrigin(),
+      isTopLevel: frame.isToplevel(),
+      isEval: frame.isEval(),
+      isNative: frame.isNative(),
+      isConstructor: frame.isConstructor(),
+    };
+  });
+}
+
+function defaultPrepareStackTrace(error: Error, frames: Array<node$CallSite>): string {
+  let formattedStackTrace = error.message ? `${error.name}: ${error.message}` : `${error.name}`;
+  frames.forEach(frame => {
+    formattedStackTrace += `\n    at ${frame.toString()}`;
+  });
+  return formattedStackTrace;
+}
+
+export const __test__ = {
+  createHookedPrepareStackTrace,
+  resetPrepareStackTraceHooked() {
+    singleton.clear(PREPARE_STACK_TRACE_HOOKED_KEY);
+  },
+};

--- a/server/src/pkg/nuclide-logging/lib/types.js
+++ b/server/src/pkg/nuclide-logging/lib/types.js
@@ -1,0 +1,42 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+export type node$CallSite = CallSite;
+
+export type Logger = {
+  debug(...args: Array<any>): mixed;
+  error(...args: Array<any>): mixed;
+  fatal(...args: Array<any>): mixed;
+  info(...args: Array<any>): mixed;
+  trace(...args: Array<any>): mixed;
+  warn(...args: Array<any>): mixed;
+  isLevelEnabled(level: string): mixed;
+  setLevel(level: string): mixed;
+};
+
+export type LoggingEvent = {
+  startTime: Date;
+  categoryName: string;
+  data: Array<any>;
+  level: {
+    level: number;
+    levelStr: string;
+  };
+  logger?: {
+    category: string;
+  };
+  storageKey?: string;
+  runtime?: any;
+};
+
+export type LoggingAppender = {
+  appenders: any;
+};

--- a/server/src/pkg/nuclide-logging/lib/utils.js
+++ b/server/src/pkg/nuclide-logging/lib/utils.js
@@ -1,0 +1,80 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import log4js from 'log4js';
+
+import type {LoggingEvent} from './types';
+
+/**
+ * JSON.stringify can't stringify instance of Error. To solve this problem, we
+ * patch the errors in loggingEvent.data and convert it to an Object with 'name', 'message',
+ * 'stack' and 'stackTrace' as fields.
+ * If there is no error attached to loggingEvent.data, we create a new error and append it to
+ * loggingEvent.data, so that we could get stack information which helps categorization in
+ * logview.
+ */
+export function patchErrorsOfLoggingEvent(loggingEvent: LoggingEvent): LoggingEvent {
+  const loggingEventCopy = {...loggingEvent};
+  loggingEventCopy.data = (loggingEventCopy.data || []).slice();
+
+  if (!loggingEventCopy.data.some(item => item instanceof Error)) {
+    loggingEventCopy.data.push(new Error('Auto generated Error'));
+  }
+
+  loggingEventCopy.data = loggingEventCopy.data.map(item => {
+    if (item instanceof Error) {
+      return {
+        name: item.name,
+        message: item.message,
+        stack: item.stack,
+        stackTrace: item.stackTrace,
+      };
+    }
+    return item;
+  });
+
+  return loggingEventCopy;
+}
+
+/**
+ * Takes a loggingEvent object, returns string representation of it.
+ */
+export function serializeLoggingEvent(loggingEvent: mixed): string {
+  return JSON.stringify(loggingEvent);
+}
+
+/**
+ * Takes a string, returns an object with the correct log properties.
+ *
+ * This method has been "borrowed" from the `multiprocess` appender
+ * by `nomiddlename` (https://github.com/nomiddlename/log4js-node/blob/master/lib/appenders/multiprocess.js)
+ *
+ * Apparently, node.js serializes everything to strings when using `process.send()`,
+ * so we need smart deserialization that will recreate log date and level for further processing by
+ * log4js internals.
+ */
+export function deserializeLoggingEvent(loggingEventString: string): LoggingEvent {
+  let loggingEvent;
+  try {
+    loggingEvent = JSON.parse(loggingEventString);
+    loggingEvent.startTime = new Date(loggingEvent.startTime);
+    loggingEvent.level = log4js.levels.toLevel(loggingEvent.level.levelStr);
+  } catch (e) {
+    // JSON.parse failed, just log the contents probably a naughty.
+    loggingEvent = {
+      startTime: new Date(),
+      categoryName: 'log4js',
+      level: log4js.levels.ERROR,
+      data: ['Unable to parse log:', loggingEventString],
+    };
+  }
+  return loggingEvent;
+}

--- a/server/src/pkg/nuclide-logging/package.json
+++ b/server/src/pkg/nuclide-logging/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuclide-logging",
+  "repository": "https://github.com/facebook/nuclide",
+  "main": "./lib/main.js",
+  "version": "0.0.0",
+  "description": "Provides logging on both Nuclide client and Nuclide server",
+  "nuclide": {
+    "packageType": "Node",
+    "testRunner": "npm"
+  },
+  "scripts": {
+    "test": "node ../nuclide-jasmine/bin/jasmine-node-transpiled spec"
+  }
+}

--- a/server/src/pkg/nuclide-remote-uri/lib/main.js
+++ b/server/src/pkg/nuclide-remote-uri/lib/main.js
@@ -1,0 +1,604 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+// NuclideUri's are either a local file path, or a URI
+// of the form nuclide://<host><path>
+//
+// This package creates, queries and decomposes NuclideUris.
+
+export type NuclideUri = string;
+
+type ParsedUrl = {
+  auth: ?string;
+  href: string;
+  host: ?string;
+  hostname: ?string;
+  path: string;
+  pathname: string;
+  protocol: ?string;
+  query: ?any;
+  search: ?string;
+  slashes: ?boolean;
+};
+
+type ParsedRemoteUrl = {
+  auth: ?string;
+  href: string;
+  host: ?string;
+  hostname: string;
+  path: string;
+  pathname: string;
+  protocol: ?string;
+  query: ?any;
+  search: ?string;
+  slashes: ?boolean;
+};
+
+type ParsedPath = {
+  root: string;
+  dir: string;
+  base: string;
+  ext: string;
+  name: string;
+};
+
+import invariant from 'assert';
+// eslint-disable-next-line nuclide-internal/prefer-nuclide-uri
+import pathModule from 'path';
+
+import url from 'url';
+
+const REMOTE_PATH_URI_PREFIX = 'nuclide://';
+
+function isRemote(uri: NuclideUri): boolean {
+  return uri.startsWith(REMOTE_PATH_URI_PREFIX);
+}
+
+function isLocal(uri: NuclideUri): boolean {
+  return !isRemote(uri);
+}
+
+function createRemoteUri(hostname: string, remotePath: string): string {
+  return `nuclide://${hostname}${remotePath}`;
+}
+
+/**
+ * Parses `uri` with Node's `url.parse` and calls `decodeURI` on `href`, `path`, and `pathname` of
+ * the parsed URL object.
+ *
+ * * `url.parse` seems to apply encodeURI to the URL, and we typically don't want this behavior.
+ * * Nuclide URIs disallow use of the `hash` attribute, and any hash characters are interpreted as
+ *   as literal hashes.
+ *
+ *   For example:
+ *
+ *       parse('nuclide://f.co/path/to/#foo.txt#')
+ *       >
+ *         {
+ *           ...
+ *           path: '/path/to/#foo.txt#',
+ *           ...
+ *         }
+ */
+function parse(uri: NuclideUri): ParsedUrl {
+  if (isLocal(uri)) {
+    return {
+      auth: null,
+      host: null,
+      hostname: null,
+      href: uri,
+      path: uri,
+      pathname: uri,
+      protocol: null,
+      query: null,
+      search: null,
+      slashes: null,
+    };
+  }
+
+  const parsedUri = url.parse(_escapeBackslashes(uri));
+
+  invariant(
+    parsedUri.path,
+    `Nuclide URIs must contain paths, '${String(parsedUri.path)}' found while parsing '${uri}'`
+  );
+
+  let path = parsedUri.path;
+  // `url.parse` treates the first '#' character as the beginning of the `hash` attribute. That
+  // feature is not used in Nuclide and is instead treated as part of the path.
+  if (parsedUri.hash != null) {
+    path += parsedUri.hash;
+  }
+
+  invariant(
+    parsedUri.pathname,
+    `Nuclide URIs must contain pathnamess, '${String(parsedUri.pathname)}' found while parsing '${uri}'`
+  );
+  let pathname = parsedUri.pathname;
+  // `url.parse` treates the first '#' character as the beginning of the `hash` attribute. That
+  // feature is not used in Nuclide and is instead treated as part of the pathname.
+  if (parsedUri.hash != null) {
+    pathname += parsedUri.hash;
+  }
+
+  // Explicitly copying object properties appeases Flow's "maybe" type handling. Using the `...`
+  // operator causes null/undefined errors, and `Object.assign` bypasses type checking.
+  return {
+    auth: parsedUri.auth,
+    host: parsedUri.host,
+    hostname: parsedUri.hostname,
+    href: decodeURI(parsedUri.href),
+    path: decodeURI(path),
+    pathname: decodeURI(pathname),
+    protocol: parsedUri.protocol,
+    query: parsedUri.query,
+    search: parsedUri.search,
+    slashes: parsedUri.slashes,
+  };
+}
+
+function parseRemoteUri(remoteUri: NuclideUri): ParsedRemoteUrl {
+  if (!isRemote(remoteUri)) {
+    throw new Error('Expected remote uri. Got ' + remoteUri);
+  }
+  const parsedUri = parse(remoteUri);
+  invariant(
+    parsedUri.hostname,
+    `Remote Nuclide URIs must contain hostnames, '${String(parsedUri.hostname)}' found ` +
+    `while parsing '${remoteUri}'`
+  );
+
+  // Explicitly copying object properties appeases Flow's "maybe" type handling. Using the `...`
+  // operator causes null/undefined errors, and `Object.assign` bypasses type checking.
+  return {
+    auth: parsedUri.auth,
+    host: parsedUri.host,
+    hostname: parsedUri.hostname,
+    href: parsedUri.href,
+    path: parsedUri.path,
+    pathname: parsedUri.pathname,
+    protocol: parsedUri.protocol,
+    query: parsedUri.query,
+    search: parsedUri.search,
+    slashes: parsedUri.slashes,
+  };
+}
+
+function getPath(uri: NuclideUri): string {
+  return parse(uri).path;
+}
+
+function getHostname(remoteUri: NuclideUri): string {
+  return parseRemoteUri(remoteUri).hostname;
+}
+
+function getHostnameOpt(remoteUri: ?NuclideUri): ?string {
+  if (remoteUri == null || isLocal(remoteUri)) {
+    return null;
+  }
+
+  return getHostname(remoteUri);
+}
+
+function join(uri: NuclideUri, ...relativePath: Array<string>): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  if (isRemote(uri)) {
+    const {hostname, path} = parseRemoteUri(uri);
+    relativePath.splice(0, 0, path);
+    return createRemoteUri(
+      hostname,
+      uriPathModule.join.apply(null, relativePath));
+  } else {
+    relativePath.splice(0, 0, uri);
+    return uriPathModule.join.apply(null, relativePath);
+  }
+}
+
+function normalize(uri: NuclideUri): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  if (isRemote(uri)) {
+    const {hostname, path} = parseRemoteUri(uri);
+    return createRemoteUri(
+      hostname,
+      uriPathModule.normalize(path)
+    );
+  } else {
+    return uriPathModule.normalize(uri);
+  }
+}
+
+function normalizeDir(uri: NuclideUri): NuclideUri {
+  return ensureTrailingSeparator(normalize(uri));
+}
+
+function getParent(uri: NuclideUri): NuclideUri {
+  // TODO: Is this different than dirname?
+  return normalize(join(uri, '..'));
+}
+
+function relative(uri: NuclideUri, other: NuclideUri): string {
+  const uriPathModule = _pathModuleFor(uri);
+  const remote = isRemote(uri);
+  if (remote !== isRemote(other) ||
+      (remote && getHostname(uri) !== getHostname(other))) {
+    throw new Error(`Cannot relative urls on different hosts: ${uri} and ${other}`);
+  }
+  if (remote) {
+    return uriPathModule.relative(getPath(uri), getPath(other));
+  } else {
+    return uriPathModule.relative(uri, other);
+  }
+}
+
+function basename(uri: NuclideUri, ext: string = ''): string {
+  const uriPathModule = _pathModuleFor(uri);
+  return uriPathModule.basename(getPath(uri), ext);
+}
+
+function dirname(uri: NuclideUri): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  if (isRemote(uri)) {
+    const {hostname, path} = parseRemoteUri(uri);
+    return createRemoteUri(
+      hostname,
+      uriPathModule.dirname(path)
+    );
+  } else {
+    return uriPathModule.dirname(uri);
+  }
+}
+
+function extname(uri: NuclideUri): string {
+  const uriPathModule = _pathModuleFor(uri);
+  return uriPathModule.extname(getPath(uri));
+}
+
+function stripExtension(uri: NuclideUri): NuclideUri {
+  const ext = extname(uri);
+  if (ext.length === 0) {
+    return uri;
+  }
+
+  return uri.slice(0, -1 * ext.length);
+}
+
+/**
+ * uri is either a file: uri, or a nuclide: uri.
+ * must convert file: uri's to just a path for atom.
+ *
+ * Returns null if not a valid file: URI.
+ */
+function uriToNuclideUri(uri: string): ?string {
+  const urlParts = url.parse(_escapeBackslashes(uri), false);
+  if (urlParts.protocol === 'file:' && urlParts.path) { // only handle real files for now.
+    return urlParts.path;
+  } else if (isRemote(uri)) {
+    return uri;
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Converts local paths to file: URI's. Leaves remote URI's alone.
+ */
+function nuclideUriToUri(uri: NuclideUri): string {
+  if (isRemote(uri)) {
+    return uri;
+  } else {
+    return 'file://' + uri;
+  }
+}
+
+/**
+ * Returns true if child is equal to, or is a proper child of parent.
+ */
+function contains(parent: NuclideUri, child: NuclideUri): boolean {
+  // Can't just do startsWith here. If this directory is "www" and you
+  // are trying to check "www-base", just using startsWith would return
+  // true, even though "www-base" is at the same level as "Www", not
+  // contained in it.
+  // Also, there's an issue with a trailing separator ambiguity. A path
+  // like /abc/ does contain /abc
+  // This function is used in some performance-sensitive parts, so we
+  // want to avoid doing unnecessary string copy, as those that would
+  // result from an ensureTrailingSeparator() call
+  //
+  // First we'll check the lengths.
+  // Then check startsWith. If so, then if the two path lengths are
+  // equal OR if the next character in the path to check is a path
+  // separator, then we know the checked path is in this path.
+
+  if (child.length < parent.length) {  // A strong indication of false
+    // It could be a matter of a trailing separator, though
+    if (child.length < parent.length - 1) { // It must be more than just the separator
+      return false;
+    }
+
+    return endsWithSeparator(parent) && parent.startsWith(child);
+  }
+
+  if (!child.startsWith(parent)) {
+    return false;
+  }
+
+  if (endsWithSeparator(parent) || parent.length === child.length) {
+    return true;
+  }
+
+  const uriPathModule = _pathModuleFor(child);
+  return child.slice(parent.length).startsWith(uriPathModule.sep);
+}
+
+/**
+ * Filter an array of paths to contain only the collapsed root paths, e.g.
+ * [a/b/c, a/, c/d/, c/d/e] collapses to [a/, c/d/]
+ */
+function collapse(paths: Array<NuclideUri>): Array<NuclideUri> {
+  return paths.filter(p =>
+    !paths.some(fp => contains(fp, p) && fp !== p)
+  );
+}
+
+const hostFormatters = [];
+
+// A formatter which may shorten hostnames.
+// Returns null if the formatter won't shorten the hostname.
+export type HostnameFormatter = (uri: NuclideUri) => ?string;
+
+// Registers a host formatter for nuclideUriToDisplayString
+function registerHostnameFormatter(formatter: HostnameFormatter):
+    {dispose: () => void} {
+  hostFormatters.push(formatter);
+  return {
+    dispose: () => {
+      const index = hostFormatters.indexOf(formatter);
+      if (index >= 0) {
+        hostFormatters.splice(index, 1);
+      }
+    },
+  };
+}
+
+/**
+ * NuclideUris should never be shown to humans.
+ * This function returns a human usable string.
+ */
+function nuclideUriToDisplayString(uri: NuclideUri): string {
+  if (isRemote(uri)) {
+    let hostname = getHostname(uri);
+    for (const formatter of hostFormatters) {
+      const formattedHostname = formatter(hostname);
+      if (formattedHostname) {
+        hostname = formattedHostname;
+        break;
+      }
+    }
+    return `${hostname}/${getPath(uri)}`;
+  } else {
+    return uri;
+  }
+}
+
+function ensureTrailingSeparator(uri: NuclideUri): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  if (uri.endsWith(uriPathModule.sep)) {
+    return uri;
+  }
+
+  return uri + uriPathModule.sep;
+}
+
+function trimTrailingSeparator(uri: NuclideUri): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  let stripped = uri;
+
+  while (stripped.endsWith(uriPathModule.sep) && !isRoot(stripped)) {
+    stripped = stripped.slice(0, -1 * uriPathModule.sep.length);
+  }
+
+  return stripped;
+}
+
+function endsWithSeparator(uri: NuclideUri): boolean {
+  const uriPathModule = _pathModuleFor(uri);
+  return uri.endsWith(uriPathModule.sep);
+}
+
+function isAbsolute(uri: NuclideUri): boolean {
+  if (isRemote(uri)) {
+    return true;
+  } else {
+    return _pathModuleFor(uri).isAbsolute(uri);
+  }
+}
+
+function resolve(uri: NuclideUri, ...paths: Array<string>): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+  if (isRemote(uri)) {
+    const {hostname, path} = parseRemoteUri(uri);
+    paths.splice(0, 0, path);
+    return createRemoteUri(
+      hostname,
+      uriPathModule.resolve.apply(null, paths));
+  } else {
+    paths.splice(0, 0, uri);
+    return uriPathModule.resolve.apply(null, paths);
+  }
+}
+
+function expandHomeDir(uri: NuclideUri): NuclideUri {
+  // This function is POSIX only functionality, so using the posix path directly
+
+  // Do not expand non home relative uris
+  if (!uri.startsWith('~')) {
+    return uri;
+  }
+
+  const {HOME} = process.env;
+  invariant(HOME != null);
+
+  if (uri === '~') {
+    return HOME;
+  }
+
+  // Uris like ~abc should not be expanded
+  if (!uri.startsWith('~/')) {
+    return uri;
+  }
+
+  return pathModule.posix.resolve(HOME, uri.replace('~', '.'));
+}
+
+/**
+ * Splits a string containing local paths by an OS-specific path delimiter
+ * Useful for splitting env variables such as PATH
+ *
+ * Since remote URI might contain the delimiter, only local paths are allowed.
+ */
+function splitPathList(paths: string): Array<NuclideUri> {
+  invariant(paths.indexOf(REMOTE_PATH_URI_PREFIX) < 0, 'Splitting remote URIs is not supported');
+  const pathsModule = _pathModuleFor(paths);
+
+  return paths.split(pathsModule.delimiter);
+}
+
+/**
+ * Joins an array of local paths with an OS-specific path delimiter into a single string.
+ * Useful for constructing env variables such as PATH
+ *
+ * Since remote URI might contain the delimiter, only local paths are allowed.
+ */
+function joinPathList(paths: Array<NuclideUri>): string {
+  if (paths.length === 0) {
+    return '';
+  }
+
+  invariant(paths.every(path => !isRemote(path)), 'Joining of remote URIs is not supported');
+
+  const uriPathModule = _pathModuleFor(paths[0]);
+  return paths.join(uriPathModule.delimiter);
+}
+
+/**
+ * This function prepends the given relative path with a "current-folder" prefix
+ * which is `./` on *nix and .\ on Windows
+ */
+function ensureLocalPrefix(uri: NuclideUri): NuclideUri {
+  const uriPathModule = _pathModuleFor(uri);
+
+  invariant(!isRemote(uri), 'Local prefix can not be added to a remote path');
+  invariant(!isAbsolute(uri), 'Local prefix can not be added to an absolute path');
+
+  const localPrefix = `.${uriPathModule.sep}`;
+  if (uri.startsWith(localPrefix)) {
+    return uri;
+  }
+
+  return localPrefix + uri;
+}
+
+function isRoot(uri: NuclideUri): boolean {
+  return dirname(uri) === uri;
+}
+
+function parsePath(uri: NuclideUri): ParsedPath {
+  const uriPathModule = _pathModuleFor(uri);
+  return uriPathModule.parse(getPath(uri));
+}
+
+export function split(uri: string): Array<string> {
+  const parts = [];
+  let current = uri;
+  let parent = dirname(current);
+
+  while (current !== parent) {
+    parts.push(basename(current));
+
+    current = parent;
+    parent = dirname(current);
+  }
+
+  if (isAbsolute(uri)) {
+    parts.push(parent);
+  }
+  parts.reverse();
+  return parts;
+}
+
+function _pathModuleFor(uri: NuclideUri): any {
+  const posixPath = pathModule.posix;
+  const win32Path = pathModule.win32;
+
+  if (uri.startsWith(posixPath.sep)) {
+    return posixPath;
+  }
+  if (uri.indexOf('://') > -1) {
+    return posixPath;
+  }
+  if (uri[1] === ':' && uri[2] === win32Path.sep) {
+    return win32Path;
+  }
+
+  if (uri.split(win32Path.sep).length > uri.split(posixPath.sep).length) {
+    return win32Path;
+  } else {
+    return posixPath;
+  }
+}
+
+/**
+ * The backslash character (\) is unfortunately a valid symbol to be used in POSIX paths.
+ * It, however, is being automatically "corrected" by node's `url.parse()` method if not escaped
+ * properly.
+ */
+function _escapeBackslashes(uri: NuclideUri): NuclideUri {
+  return uri.replace(/\\/g, '%5C');
+}
+
+export default {
+  basename,
+  dirname,
+  extname,
+  stripExtension,
+  isRemote,
+  isLocal,
+  createRemoteUri,
+  parse,
+  parseRemoteUri,
+  getPath,
+  getHostname,
+  getHostnameOpt,
+  join,
+  relative,
+  normalize,
+  normalizeDir,
+  getParent,
+  uriToNuclideUri,
+  nuclideUriToUri,
+  contains,
+  collapse,
+  nuclideUriToDisplayString,
+  registerHostnameFormatter,
+  ensureTrailingSeparator,
+  trimTrailingSeparator,
+  endsWithSeparator,
+  isAbsolute,
+  resolve,
+  expandHomeDir,
+  splitPathList,
+  joinPathList,
+  ensureLocalPrefix,
+  isRoot,
+  parsePath,
+  split,
+  _pathModuleFor,  // Exported for tests only
+};

--- a/server/src/pkg/nuclide-remote-uri/package.json
+++ b/server/src/pkg/nuclide-remote-uri/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuclide-remote-uri",
+  "repository": "https://github.com/facebook/nuclide",
+  "main": "./lib/main.js",
+  "version": "0.0.0",
+  "description": "RemoteUri - provides local and remote nuclide file path functions.",
+  "nuclide": {
+    "packageType": "Node",
+    "testRunner": "npm"
+  },
+  "scripts": {
+    "test": "node ../nuclide-jasmine/bin/jasmine-node-transpiled spec"
+  }
+}

--- a/server/src/pkg/nuclide-tokenized-text/lib/main.js
+++ b/server/src/pkg/nuclide-tokenized-text/lib/main.js
@@ -1,0 +1,76 @@
+'use babel';
+/* @flow */
+
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+
+// This type is duplicated in nuclide-flow-base/lib/FlowService.js
+// When updating update both locations!
+export type TokenKind = 'keyword'
+  | 'class-name'
+  | 'constructor'
+  | 'method'
+  | 'param'
+  | 'string'
+  | 'whitespace'
+  | 'plain'
+  | 'type'
+  ;
+
+// This type is duplicated in nuclide-flow-base/lib/FlowService.js
+// When updating update both locations!
+export type TextToken = {
+  kind: TokenKind;
+  value: string;
+};
+
+// This type is duplicated in nuclide-flow-base/lib/FlowService.js
+// When updating update both locations!
+export type TokenizedText = Array<TextToken>;
+
+export function keyword(value: string): TextToken {
+  return _buildToken('keyword', value);
+}
+
+export function className(value: string): TextToken {
+  return _buildToken('class-name', value);
+}
+
+export function constructor(value: string): TextToken {
+  return _buildToken('constructor', value);
+}
+
+export function method(value: string): TextToken {
+  return _buildToken('method', value);
+}
+
+export function param(value: string): TextToken {
+  return _buildToken('param', value);
+}
+
+export function string(value: string): TextToken {
+  return _buildToken('string', value);
+}
+
+export function whitespace(value: string): TextToken {
+  return _buildToken('whitespace', value);
+}
+
+export function plain(value: string): TextToken {
+  return _buildToken('plain', value);
+}
+
+export function type(value: string): TextToken {
+  return _buildToken('type', value);
+}
+
+
+function _buildToken(kind: TokenKind, value: string): TextToken {
+  return {kind, value};
+}

--- a/server/src/pkg/nuclide-tokenized-text/package.json
+++ b/server/src/pkg/nuclide-tokenized-text/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nuclide-tokenized-text",
+  "repository": "https://github.com/facebook/nuclide",
+  "main": "./lib/main.js",
+  "version": "0.0.0",
+  "description": "Contains support for the tokenized-text (currently) used for the outline feature.",
+  "atomTestRunner": "../../lib/test-runner.js",
+  "nuclide": {
+    "packageType": "Node",
+    "testRunner": "apm"
+  }
+}


### PR DESCRIPTION
This can mostly be ignored, as it just vendors in the flow abstractions from flow-for-vscode, which themselves are vendored from Nuclide. These will eventually be upgraded to their current equivalents in nuclide right now.

This was broken out into a separate PR to reduce noise in the others.