### PR TITLE
Consume Nuclide datatips and Linter v2

### DIFF
--- a/atom-languageserver-flow/package.json
+++ b/atom-languageserver-flow/package.json
@@ -14,17 +14,22 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "linter-indie": {
+      "versions": {
+        "2.0.0": "consumeLinterV2"
+      }
+    },
+    "nuclide-datatip.provider": {
+      "versions": {
+        "0.0.0": "consumeDatatip"
+      }
     }
   },
   "providedServices": {
     "autocomplete.provider": {
       "versions": {
         "2.0.0": "provideAutocomplete"
-      }
-    },
-    "linter": {
-      "versions": {
-        "1.0.0": "provideLinter"
       }
     },
     "nuclide-outline-view": {

--- a/server/src/Hover.js
+++ b/server/src/Hover.js
@@ -8,10 +8,6 @@ import URI from 'vscode-uri';
 import TextDocuments from './TextDocuments';
 import {atomRangeToLSPRange, lspPositionToAtomPoint} from './utils/util';
 
-function markedJS(text: string): string {
-  return '```js\n' + text + '\n```';
-}
-
 type HoverSupportParams = {
   connection: IConnection,
   documents: TextDocuments,
@@ -44,7 +40,7 @@ export default class HoverSupport {
 
     if (typeHint) {
       return {
-        contents: markedJS(typeHint.hint),
+        contents: {language: 'javascript', value: typeHint.hint},
         range: atomRangeToLSPRange(typeHint.range),
       };
     }


### PR DESCRIPTION
Also, to make this look better, provide code snippets rather than pure markdown on hover.
The latest `atom-languageclient` now supports both of these!