### PR TITLE
Fix an error where the sanitized rootPath was not forwarded on.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export function createServer(
     logger.debug('LSP connection initialized. Connecting to flow...');
 
     const flowVersionInfo = await getFlowVersionInfo(
-      rootPath,
+      root,
       connection,
       initialFlowOptions,
     );


### PR DESCRIPTION
Previously, if the `rootPath` were `null`, then it was not handled
correctly, but this appears to fix things.