### PR TITLE
Remove dependency on connection in feature providers

### DIFF
--- a/src/Definition.js
+++ b/src/Definition.js
@@ -10,7 +10,6 @@
  * @format
  */
 
-import type {IConnection} from 'vscode-languageserver';
 import type {Definition, IRange} from 'vscode-languageserver-types';
 import type {TextDocumentPositionParams} from 'vscode-languageserver/lib/protocol';
 import type TextDocuments from './TextDocuments';
@@ -23,18 +22,15 @@ import {atomPointToLSPPosition, lspPositionToAtomPoint} from './utils/util';
 const logger = getLogger('Definition');
 
 type DefinitionSupportParams = {
-  connection: IConnection,
   documents: TextDocuments,
   flow: FlowSingleProjectLanguageService,
 };
 
 export default class DefinitionSupport {
-  connection: IConnection;
   documents: TextDocuments;
   flow: FlowSingleProjectLanguageService;
 
-  constructor({connection, documents, flow}: DefinitionSupportParams) {
-    this.connection = connection;
+  constructor({documents, flow}: DefinitionSupportParams) {
     this.documents = documents;
     this.flow = flow;
   }

--- a/src/Diagnostics.js
+++ b/src/Diagnostics.js
@@ -10,14 +10,10 @@
  * @format
  */
 
-import type {
-  IConnection,
-  PublishDiagnosticsParams,
-} from 'vscode-languageserver';
+import type {PublishDiagnosticsParams} from 'vscode-languageserver';
 import type {FileDiagnosticMessage, FileDiagnosticMessages} from 'atom-ide-ui';
 
 import URI from 'vscode-uri';
-import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
 
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 import {atomRangeToLSPRange, flowSeverityToLSPSeverity} from './utils/util';
@@ -26,37 +22,22 @@ import {getLogger} from 'log4js';
 const logger = getLogger('Diagnostics');
 
 type DiagnosticsParams = {
-  connection: IConnection,
   flow: FlowSingleProjectLanguageService,
 };
 
 export default class Diagnostics {
-  connection: IConnection;
   flow: FlowSingleProjectLanguageService;
-  _disposable: UniversalDisposable = new UniversalDisposable();
 
-  constructor({connection, flow}: DiagnosticsParams) {
-    this.connection = connection;
+  constructor({flow}: DiagnosticsParams) {
     this.flow = flow;
-  }
-
-  dispose() {
-    this._disposable.dispose();
   }
 
   observe() {
     logger.info('Beginning to observe diagnostics');
 
-    this._disposable.add(
-      this.flow
-        .observeDiagnostics()
-        .map(diagnostics =>
-          diagnostics.map(fileDiagnosticUpdateToLSPDiagnostic),
-        )
-        .subscribe(diagnostics =>
-          diagnostics.forEach(this.connection.sendDiagnostics),
-        ),
-    );
+    return this.flow
+      .observeDiagnostics()
+      .map(diagnostics => diagnostics.map(fileDiagnosticUpdateToLSPDiagnostic));
   }
 }
 

--- a/src/Hover.js
+++ b/src/Hover.js
@@ -10,7 +10,6 @@
  * @format
  */
 
-import type {IConnection} from 'vscode-languageserver';
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 
 import URI from 'vscode-uri';
@@ -19,7 +18,6 @@ import TextDocuments from './TextDocuments';
 import {atomRangeToLSPRange, lspPositionToAtomPoint} from './utils/util';
 
 type HoverSupportParams = {
-  connection: IConnection,
   documents: TextDocuments,
   flow: FlowSingleProjectLanguageService,
 };
@@ -29,12 +27,10 @@ const NULL_HOVER = {
 };
 
 export default class HoverSupport {
-  connection: IConnection;
   documents: TextDocuments;
   flow: FlowSingleProjectLanguageService;
 
-  constructor({connection, documents, flow}: HoverSupportParams) {
-    this.connection = connection;
+  constructor({documents, flow}: HoverSupportParams) {
     this.documents = documents;
     this.flow = flow;
   }

--- a/src/Symbol.js
+++ b/src/Symbol.js
@@ -10,7 +10,6 @@
  * @format
  */
 
-import type {IConnection} from 'vscode-languageserver';
 import type {DocumentSymbolParams} from 'vscode-languageserver-types';
 import type {OutlineTree} from 'atom-ide-ui';
 
@@ -26,18 +25,15 @@ import {getLogger} from 'log4js';
 const logger = getLogger('Symbol');
 
 type SymbolSupportParams = {
-  connection: IConnection,
   documents: TextDocuments,
   flow: FlowSingleProjectLanguageService,
 };
 
 export default class SymbolSupport {
-  connection: IConnection;
   documents: TextDocuments;
   flow: FlowSingleProjectLanguageService;
 
-  constructor({connection, documents, flow}: SymbolSupportParams) {
-    this.connection = connection;
+  constructor({documents, flow}: SymbolSupportParams) {
     this.documents = documents;
     this.flow = flow;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,15 @@ export function createServer(
           }),
       );
 
-      const diagnostics = new Diagnostics({connection, flow});
-      disposable.add(diagnostics);
-      diagnostics.observe();
+      const diagnostics = new Diagnostics({flow});
+
+      disposable.add(
+        diagnostics
+          .observe()
+          .subscribe(diagnosticItems =>
+            diagnosticItems.forEach(connection.sendDiagnostics),
+          ),
+      );
 
       const completion = new Completion({
         clientCapabilities: capabilities,
@@ -94,7 +100,7 @@ export function createServer(
         // information on resolve, but need to respond to implement completion
       });
 
-      const definition = new Definition({connection, documents, flow});
+      const definition = new Definition({documents, flow});
       connection.onDefinition(docParams => {
         logger.debug(
           `definition requested for document ${docParams.textDocument.uri}`,
@@ -102,12 +108,12 @@ export function createServer(
         return definition.provideDefinition(docParams);
       });
 
-      const hover = new Hover({connection, documents, flow});
+      const hover = new Hover({documents, flow});
       connection.onHover(docParams => {
         return hover.provideHover(docParams);
       });
 
-      const symbols = new SymbolSupport({connection, documents, flow});
+      const symbols = new SymbolSupport({documents, flow});
       connection.onDocumentSymbol(symbolParams => {
         logger.debug(
           `symbols requested for document ${symbolParams.textDocument.uri}`,


### PR DESCRIPTION
Many providers declared this dependency but never used it. In the case of diagnostics, which used `connection` and used it for side-effects, instead return an observable and have these effects happen in `index.js`.