### PR TITLE
Port over some fixes from Nuclide's Flow code

### DIFF
--- a/src/pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService.js
+++ b/src/pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService.js
@@ -311,7 +311,10 @@ export class FlowSingleProjectLanguageService {
     // Allows completions to immediately appear when we are completing off of object properties.
     // This also needs to be changed if minimumPrefixLength goes above 1, since after you type a
     // single alphanumeric character, autocomplete-plus no longer includes the dot in the prefix.
-    const prefixHasDot = prefix.indexOf('.') !== -1;
+    const prefixHasDot =
+      // charAt(index) returns an empty string if the index is out of bounds
+      buffer.lineForRow(position.row).charAt(position.column - 1) === '.' ||
+      prefix.indexOf('.') !== -1;
 
     if (
       !activatedManually &&

--- a/src/pkg/nuclide-flow-rpc/lib/diagnosticsParser.js
+++ b/src/pkg/nuclide-flow-rpc/lib/diagnosticsParser.js
@@ -51,7 +51,9 @@ export function diagnosticToFix(
   return null;
 }
 
-const fixExtractionFunctions: Array<(diagnostic: FileDiagnosticMessage) => ?DiagnosticFix, > = [unusedSuppressionFix, namedImportTypo];
+const fixExtractionFunctions: Array<
+  (diagnostic: FileDiagnosticMessage) => ?DiagnosticFix,
+> = [unusedSuppressionFix, namedImportTypo];
 
 function unusedSuppressionFix(
   diagnostic: FileDiagnosticMessage,
@@ -155,7 +157,9 @@ function flowMessageToDiagnosticMessage(flowStatusError: FlowStatusError) {
 
   // The Flow type does not capture this, but the first message always has a path, and the
   // diagnostics package requires a FileDiagnosticMessage to have a path.
-  const path = extractPath(mainMessage);
+  const path = flowMessageComponents
+    .map(extractPath)
+    .find(extractedPath => extractedPath != null);
   invariant(path != null, 'Expected path to not be null or undefined');
 
   const diagnosticMessage: FileDiagnosticMessage = {

--- a/src/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
+++ b/src/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
@@ -58,6 +58,8 @@ type Group = {
   elements: Array<Element>,
   openChar: string,
   closeChar: string,
+  exactChar: '|' | '',
+  isExact: boolean,
   start: number,
   end: number,
   parentGroup: ?Group,
@@ -66,6 +68,8 @@ type Group = {
 function parseGroups(str) {
   const rootGroup: Group = {
     elements: [{start: 0, end: -1, groups: []}],
+    isExact: false,
+    exactChar: '',
     openChar: '',
     closeChar: '',
     start: 0,
@@ -76,23 +80,30 @@ function parseGroups(str) {
   let currentGroup: Group = rootGroup;
   let i = 0;
 
-  function pushGroup() {
+  function pushGroup(isExact: boolean) {
     const group = {
       start: i,
       end: -1,
       openChar: str[i],
       closeChar: closeGroup[openGroup.indexOf(str[i])],
-      elements: [{start: i + 1, end: -1, groups: []}],
+      exactChar: isExact ? '|' : '',
+      isExact,
+      elements: [],
       parentGroup: currentGroup,
     };
+    if (isExact) {
+      i++;
+    }
+    group.elements.push({start: i + 1, end: -1, groups: []});
     const currentElement = last(currentGroup.elements);
     currentElement.groups.push(group);
     currentGroup = group;
   }
 
   function popGroup() {
+    const isExact = currentGroup.isExact;
     const currentElement = last(currentGroup.elements);
-    currentElement.end = i;
+    currentElement.end = isExact ? i - 1 : i;
     currentGroup.end = i + 1;
     const parentGroup = currentGroup.parentGroup;
     if (!parentGroup) {
@@ -109,7 +120,7 @@ function parseGroups(str) {
 
   for (; i < str.length; ++i) {
     if (openGroup.indexOf(str[i]) !== -1) {
-      pushGroup();
+      pushGroup(str[i] === '{' && str[i + 1] === '|');
     }
 
     if (
@@ -138,28 +149,28 @@ function printGroups(str, rootGroup, max) {
   }
 
   function printMultiLineGroup(group, indent) {
-    let output = group.openChar + '\n';
+    let output = group.openChar + group.exactChar + '\n';
     group.elements.forEach(element => {
       output += printElement(element, indent + 1, /* singleLine */ false);
     });
-    output += getIndent(indent) + group.closeChar;
+    output += getIndent(indent) + group.exactChar + group.closeChar;
     return output;
   }
 
   function printSingleLineGroupWithoutEnforcingChildren(group, indent) {
-    let output = group.openChar;
+    let output = group.openChar + group.exactChar;
     group.elements.forEach(childGroup => {
       output += printElement(childGroup, indent, /* singleLine */ false).trim();
     });
-    return output + group.closeChar;
+    return output + group.exactChar + group.closeChar;
   }
 
   function printSingleLineGroup(group, indent) {
-    let output = group.openChar;
+    let output = group.openChar + group.exactChar;
     group.elements.forEach(childGroup => {
       output += printElement(childGroup, indent, /* singleLine */ true);
     });
-    return output + group.closeChar;
+    return output + group.exactChar + group.closeChar;
   }
 
   function printGroup(group, indent, singleLine) {


### PR DESCRIPTION
I synced over a few fixes from Nuclide's flow code:

1) Make sure "builtin" errors don't throw errors by attempting to find a suitable path.
2) Improve pretty-printing of exact types.
3) Fix autocompletion in certain cases (not sure if this affects the LSP path).

1 potentially fixes some of the issues in https://github.com/flowtype/ide-flowtype/issues/10.