### PR TITLE
Fixes for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ It also requires [any supported operating system platform for Flow](https://gith
 ## Installation
 You most likely don't need to install `flow-language-server` directly if you want Flow support for your favorite editor; instead, [check out the integrations below](#editor-integrations).
 
-**Windows is not currently fully supported. This is being actively worked on.**
-
 ## How it works
 `flow-language-server` wraps the existing flow server binary the user has installed either locally in their project as the `flow-bin` module from npm, or globally as the `flow` binary. `flow-language-server` translates messages as they come in from Flow, sending them over JSON RPC via stdio, node-ipc, a socket, or a named pipe. It also, for the time being, automatically downloads and manages any missing flow binaries, though this probably is best suited to each individual editor integration.
 

--- a/src/Completion.js
+++ b/src/Completion.js
@@ -30,7 +30,7 @@ import {wordAtPositionFromBuffer} from 'nuclide-commons/range';
 
 import TextDocuments from './TextDocuments';
 import {JAVASCRIPT_WORD_REGEX} from './pkg/nuclide-flow-common';
-import {lspPositionToAtomPoint} from './utils/util';
+import {lspPositionToAtomPoint, fileURIToPath} from './utils/util';
 import {getLogger} from 'log4js';
 
 const logger = getLogger('Completion');
@@ -56,7 +56,7 @@ export default class Completion {
     textDocument,
     position,
   }: TextDocumentPositionParams): Promise<ICompletionList> {
-    const fileName = URI.parse(textDocument.uri).fsPath;
+    const fileName = fileURIToPath(textDocument.uri);
     const doc = this.documents.get(textDocument.uri);
     const point = lspPositionToAtomPoint(position);
     // $FlowFixMe: Add to defs

--- a/src/Completion.js
+++ b/src/Completion.js
@@ -21,7 +21,6 @@ import type {
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 
 import {Range} from 'simple-text-buffer';
-import URI from 'vscode-uri';
 import {
   CompletionItemKind,
   InsertTextFormat,

--- a/src/Definition.js
+++ b/src/Definition.js
@@ -17,7 +17,11 @@ import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowS
 
 import URI from 'vscode-uri';
 import {getLogger} from 'log4js';
-import {atomPointToLSPPosition, lspPositionToAtomPoint} from './utils/util';
+import {
+  atomPointToLSPPosition,
+  lspPositionToAtomPoint,
+  fileURIToPath,
+} from './utils/util';
 
 const logger = getLogger('Definition');
 
@@ -39,7 +43,7 @@ export default class DefinitionSupport {
     textDocument,
     position,
   }: TextDocumentPositionParams): Promise<?Definition> {
-    const fileName = URI.parse(textDocument.uri).fsPath;
+    const fileName = fileURIToPath(textDocument.uri);
     const doc = this.documents.get(textDocument.uri);
 
     const definitionResults = await this.flow.getDefinition(

--- a/src/Diagnostics.js
+++ b/src/Diagnostics.js
@@ -18,7 +18,11 @@ import type {Observable} from 'rxjs';
 import URI from 'vscode-uri';
 
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
-import {atomRangeToLSPRange, flowSeverityToLSPSeverity} from './utils/util';
+import {
+  atomRangeToLSPRange,
+  flowSeverityToLSPSeverity,
+  fileURIToPath,
+} from './utils/util';
 import {getLogger} from 'log4js';
 
 const logger = getLogger('Diagnostics');
@@ -37,7 +41,7 @@ export default class Diagnostics {
   async diagnoseOne(
     document: TextDocument,
   ): Promise<Array<PublishDiagnosticsParams>> {
-    const documentPath = URI.parse(document.uri).fsPath;
+    const documentPath = fileURIToPath(document.uri);
     if (!documentPath) {
       return [];
     }

--- a/src/Hover.js
+++ b/src/Hover.js
@@ -12,8 +12,6 @@
 
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 
-import URI from 'vscode-uri';
-
 import TextDocuments from './TextDocuments';
 import {
   atomRangeToLSPRange,

--- a/src/Hover.js
+++ b/src/Hover.js
@@ -15,7 +15,11 @@ import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowS
 import URI from 'vscode-uri';
 
 import TextDocuments from './TextDocuments';
-import {atomRangeToLSPRange, lspPositionToAtomPoint} from './utils/util';
+import {
+  atomRangeToLSPRange,
+  lspPositionToAtomPoint,
+  fileURIToPath,
+} from './utils/util';
 
 type HoverSupportParams = {
   documents: TextDocuments,
@@ -38,7 +42,7 @@ export default class HoverSupport {
   async provideHover(params: TextDocumentPositionParams): Promise<?Hover> {
     const {position, textDocument} = params;
 
-    const fileName = URI.parse(textDocument.uri).fsPath;
+    const fileName = fileURIToPath(textDocument.uri);
     const doc = this.documents.get(textDocument.uri);
 
     const typeHint = await this.flow.typeHint(

--- a/src/Symbol.js
+++ b/src/Symbol.js
@@ -14,7 +14,6 @@ import type {DocumentSymbolParams} from 'vscode-languageserver-types';
 import type {OutlineTree} from 'atom-ide-ui';
 
 import nullthrows from 'nullthrows';
-import URI from 'vscode-uri';
 import {SymbolKind, ISymbolInformation} from 'vscode-languageserver-types';
 
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';

--- a/src/Symbol.js
+++ b/src/Symbol.js
@@ -19,7 +19,7 @@ import {SymbolKind, ISymbolInformation} from 'vscode-languageserver-types';
 
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 import TextDocuments from './TextDocuments';
-import {atomPointToLSPPosition} from './utils/util';
+import {atomPointToLSPPosition, fileURIToPath} from './utils/util';
 import {getLogger} from 'log4js';
 
 const logger = getLogger('Symbol');
@@ -44,7 +44,7 @@ export default class SymbolSupport {
     logger.debug('document symbols requested');
     const {textDocument} = params;
 
-    const fileName = URI.parse(textDocument.uri).fsPath;
+    const fileName = fileURIToPath(textDocument.uri);
     const doc = this.documents.get(textDocument.uri);
 
     const outline = await this.flow.getOutline(fileName, doc.buffer);

--- a/src/flow-versions/flowBinForRoot.js
+++ b/src/flow-versions/flowBinForRoot.js
@@ -37,11 +37,6 @@ type FlowBinForPathOptions = {
   reporter?: Reporter,
 };
 
-const FLOW_BIN_PATH = path.join(
-  'node_modules',
-  '.bin',
-  process.platform === 'win32' ? 'flow.cmd' : 'flow',
-);
 const flowConfigCache = new ConfigCache(['.flowconfig']);
 
 export async function flowBinForPath(
@@ -61,10 +56,17 @@ export async function flowBinForPath(
   reporter.info(`Looking for a version of flow matching ${semversion}...`);
 
   if (tryFlowBin) {
-    const versionInfo = await versionInfoForPath(
+    let versionInfo = await versionInfoForPath(
       rootPath,
-      nuclideUri.join(rootPath, FLOW_BIN_PATH),
+      nuclideUri.join(rootPath, 'node_modules', '.bin', BIN_NAME),
     );
+    if (versionInfo == null && process.platform === 'win32') {
+      // In newer flow-bin versions, flow.cmd is used instead of flow.exe.
+      versionInfo = await versionInfoForPath(
+        rootPath,
+        nuclideUri.join(rootPath, 'node_modules', '.bin', 'flow.cmd'),
+      );
+    }
 
     reporter.info('version info', versionInfo);
     if (versionInfo) {

--- a/src/flow-versions/flowBinForRoot.js
+++ b/src/flow-versions/flowBinForRoot.js
@@ -37,7 +37,11 @@ type FlowBinForPathOptions = {
   reporter?: Reporter,
 };
 
-const FLOW_BIN_PATH = path.join('node_modules', '.bin', BIN_NAME);
+const FLOW_BIN_PATH = path.join(
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'flow.cmd' : 'flow',
+);
 const flowConfigCache = new ConfigCache(['.flowconfig']);
 
 export async function flowBinForPath(

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ import type {InitializeParams} from 'vscode-languageserver/lib/protocol';
 import type {VersionInfo} from './flow-versions/types';
 
 import nuclideUri from 'nuclide-commons/nuclideUri';
-import path from 'path';
 import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
+import path from 'path';
 import {IConnection} from 'vscode-languageserver';
 
 import Completion from './Completion';

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import type {InitializeParams} from 'vscode-languageserver/lib/protocol';
 import type {VersionInfo} from './flow-versions/types';
 
 import nuclideUri from 'nuclide-commons/nuclideUri';
+import path from 'path';
 import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
 import {IConnection} from 'vscode-languageserver';
 
@@ -50,7 +51,9 @@ export function createServer(
 
   connection.onInitialize(
     async ({capabilities, rootPath}: InitializeParams) => {
-      const root = rootPath || process.cwd();
+      // Flow trips on trailing slashes in root on Windows, `path.resolve` gets
+      // rid of it.
+      const root = path.resolve(rootPath || process.cwd());
 
       logger.debug('LSP connection initialized. Connecting to flow...');
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -35,8 +35,22 @@ const flowSeverityToLSPSeverityMap: {
   [FlowSeverity.Warning]: DiagnosticSeverity.Warning,
 };
 
+const FILE_PROTOCOL = 'file://';
+
 export function toURI(filePath: string): URI {
   return URI.file(filePath);
+}
+
+export function fileURIToPath(fileUri: string): string {
+  invariant(fileUri.startsWith(FILE_PROTOCOL), 'Must pass a valid file URI');
+
+  let localPath = fileUri.slice(FILE_PROTOCOL.length);
+  // On Windows remove the leading slash and convert to backslashes.
+  if (process.platform === 'win32') {
+    localPath = localPath.slice(1).replace(/\//g, '\\');
+  }
+
+  return localPath;
 }
 
 export function hasFlowPragma(content: string) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -42,15 +42,21 @@ export function toURI(filePath: string): URI {
 }
 
 export function fileURIToPath(fileUri: string): string {
+  if (process.platform !== 'win32') {
+    return URI.parse(fileUri).fsPath;
+  }
+
+  // On Windows, vscode-uri converts drive paths to lowercase,
+  // which Flow doesn't like very much.
+  // We'll implement our own basic converter.
   invariant(fileUri.startsWith(FILE_PROTOCOL), 'Must pass a valid file URI');
 
   let localPath = fileUri.slice(FILE_PROTOCOL.length);
-  // On Windows remove the leading slash and convert to backslashes.
-  if (process.platform === 'win32') {
-    localPath = localPath.slice(1).replace(/\//g, '\\');
+  // Remove the leading slash and convert to backslashes.
+  if (localPath.startsWith('/')) {
+    localPath = localPath.substr(1);
   }
-
-  return localPath;
+  return localPath.replace(/\//g, '\\');
 }
 
 export function hasFlowPragma(content: string) {


### PR DESCRIPTION
Fixes a few things needed for windows support. Flow is pretty strict about what it expect to work, ideally this would also be fixed in Flow but for now we can workaround those things here.

- For some reason vscode-uri normalizes drive letter to lowercase here https://github.com/Microsoft/vscode-uri/blob/master/lib/index.ts#L131 and this causes issues because Flow uses case sensitive paths even on Windows where it is not. As a workaround I implemented a super simple file uri parsing function that works for our use case and handles windows paths without lowercasing drive letter. Ideally this could be fixed upstream in vscode-uri but there might be a reason why they do this and will be a breaking change so doing this is a lot easier and less disruptive.

- The flow binary under `node_modules/.bin` is actually flow.cmd and now flow.exe

- The project root returned by the language server spec has a trailing slash and flow trips on it on Windows. `path.resolve` gets rid of it.

Tested that the ide-flowtype extension using this patched version of flow-language-server works on windows and mac os (don't have linux setup but it should be different than mac os).