### PR TITLE
Fix diagnostic not showing up in editor on Windows

### DIFF
--- a/src/Definition.js
+++ b/src/Definition.js
@@ -15,12 +15,12 @@ import type {TextDocumentPositionParams} from 'vscode-languageserver/lib/protoco
 import type TextDocuments from './TextDocuments';
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 
-import URI from 'vscode-uri';
 import {getLogger} from 'log4js';
 import {
   atomPointToLSPPosition,
   lspPositionToAtomPoint,
   fileURIToPath,
+  filePathToURI,
 } from './utils/util';
 
 const logger = getLogger('Definition');
@@ -62,7 +62,7 @@ export default class DefinitionSupport {
         };
 
         return {
-          uri: URI.file(def.path).toString(),
+          uri: filePathToURI(def.path),
           range,
         };
       });

--- a/src/Diagnostics.js
+++ b/src/Diagnostics.js
@@ -15,13 +15,12 @@ import type {FileDiagnosticMessage, FileDiagnosticMessages} from 'atom-ide-ui';
 import type TextDocument from './TextDocument';
 import type {Observable} from 'rxjs';
 
-import URI from 'vscode-uri';
-
 import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
 import {
   atomRangeToLSPRange,
   flowSeverityToLSPSeverity,
   fileURIToPath,
+  filePathToURI,
 } from './utils/util';
 import {getLogger} from 'log4js';
 
@@ -75,7 +74,7 @@ function fileDiagnosticUpdateToLSPDiagnostic(
   diagnostic: FileDiagnosticMessages,
 ): PublishDiagnosticsParams {
   return {
-    uri: URI.file(diagnostic.filePath).toString(),
+    uri: filePathToURI(diagnostic.filePath),
     diagnostics: diagnostic.messages
       .filter(
         // range and message text are required for LSP

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -37,8 +37,17 @@ const flowSeverityToLSPSeverityMap: {
 
 const FILE_PROTOCOL = 'file://';
 
-export function toURI(filePath: string): URI {
-  return URI.file(filePath);
+// On Windows, vscode-uri converts drive paths to lowercase,
+// which Flow doesn't like very much.
+// We'll implement our own basic converters `filePathToURI` and
+// `fileURIToPath`.
+
+export function filePathToURI(filePath: string): string {
+  if (process.platform !== 'win32') {
+    return URI.file(filePath).toString();
+  }
+
+  return encodeURI(FILE_PROTOCOL + '/' + filePath.replace(/\\/g, '/'));
 }
 
 export function fileURIToPath(fileUri: string): string {
@@ -46,9 +55,6 @@ export function fileURIToPath(fileUri: string): string {
     return URI.parse(fileUri).fsPath;
   }
 
-  // On Windows, vscode-uri converts drive paths to lowercase,
-  // which Flow doesn't like very much.
-  // We'll implement our own basic converter.
   invariant(fileUri.startsWith(FILE_PROTOCOL), 'Must pass a valid file URI');
 
   let localPath = fileUri.slice(FILE_PROTOCOL.length);


### PR DESCRIPTION
Removes last usages of vscode-uri and replace them by our own util function that has a patch for windows drive letters.

This caused diagnostics to not display properly in editor panes (worked fine in the diagnostics panel).

Tested that it now works properly on Windows and that there are no usages left of vscode-uri outside of utils.js.