### PR TITLE
Respond completionItem/resolve requests with received item

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import nuclideUri from 'nuclide-commons/nuclideUri';
 import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
 import path from 'path';
 import {IConnection} from 'vscode-languageserver';
+import type {ICompletionItem} from 'vscode-languageserver-types';
 
 import Completion from './Completion';
 import Definition from './Definition';
@@ -112,9 +113,12 @@ export function createServer(
         return completion.provideCompletionItems(docParams);
       });
 
-      connection.onCompletionResolve(() => {
-        // for now, noop as we can't/don't need to provide any additional
-        // information on resolve, but need to respond to implement completion
+      connection.onCompletionResolve((item: ICompletionItem) => {
+        // for now, we return the item as is as we can't/don't need to provide
+        // any additional information on resolve, but need to respond to
+        // implement completion
+        logger.debug(`completionItem/resolve requested for item ${item.label}`);
+        return item;
       });
 
       const definition = new Definition({documents, flow});


### PR DESCRIPTION
We are declaring `capabilities.completionProvider.resolveProvider = true`, which makes some clients use the response from `completionItem/resolve` as the completion item.

Spec: https://microsoft.github.io/language-server-protocol/specification#completion-item-resolve-request-leftwards_arrow_with_hook