### PR TITLE
Implement textDocument/documentHighlight

### DIFF
--- a/packages/flow-language-server/src/DocumentHighlight.js
+++ b/packages/flow-language-server/src/DocumentHighlight.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @format
+ */
+
+import {FlowSingleProjectLanguageService} from './pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService';
+
+import TextDocuments from './TextDocuments';
+import {
+  atomPointToLSPPosition,
+  lspPositionToAtomPoint,
+  fileURIToPath,
+} from './utils/util';
+
+type DocumentHighlightSupportParams = {
+  documents: TextDocuments,
+  flow: FlowSingleProjectLanguageService,
+};
+
+export default class DocumentHighlightSupport {
+  documents: TextDocuments;
+  flow: FlowSingleProjectLanguageService;
+
+  constructor({documents, flow}: DocumentHighlightSupportParams) {
+    this.documents = documents;
+    this.flow = flow;
+  }
+
+  async provideDocumentHighlight(
+    params: TextDocumentPositionParams,
+  ): Promise<?(DocumentHighlight[])> {
+    const {position, textDocument} = params;
+
+    const fileName = fileURIToPath(textDocument.uri);
+    const doc = this.documents.get(textDocument.uri);
+
+    const highlights = await this.flow.highlight(
+      fileName,
+      doc.buffer,
+      lspPositionToAtomPoint(position),
+    );
+    if (highlights) {
+      return highlights.map(highlight => {
+        return {
+          range: {
+            start: atomPointToLSPPosition(highlight.start),
+            end: atomPointToLSPPosition(highlight.end),
+          },
+        };
+      });
+    }
+    return null;
+  }
+}

--- a/packages/flow-language-server/src/index.js
+++ b/packages/flow-language-server/src/index.js
@@ -23,6 +23,7 @@ import type {ICompletionItem} from 'vscode-languageserver-types';
 import Completion from './Completion';
 import Definition from './Definition';
 import Diagnostics from './Diagnostics';
+import DocumentHighlight from './DocumentHighlight';
 import Hover from './Hover';
 import SymbolSupport from './Symbol';
 import TextDocuments from './TextDocuments';
@@ -133,6 +134,11 @@ export function createServer(
         return definition.provideDefinition(docParams);
       });
 
+      const documentHighlight = new DocumentHighlight({documents, flow});
+      connection.onDocumentHighlight(docParams => {
+        return documentHighlight.provideDocumentHighlight(docParams);
+      });
+
       const hover = new Hover({documents, flow});
       connection.onHover(docParams => {
         return hover.provideHover(docParams);
@@ -157,6 +163,7 @@ export function createServer(
             resolveProvider: true,
             triggerCharacters: ['.'],
           },
+          documentHighlightProvider: true,
           hoverProvider: true,
         },
       };


### PR DESCRIPTION
I used the [Hover.js class](https://github.com/flowtype/flow-language-server/blob/daa83c3bc5d6323f0e1ce17bfd38c04ad43f52b9/packages/flow-language-server/src/Hover.js) as a reference to implementing the `textDocument/documentHighlight` request. Unfortunately, the Flow server doesn't seem to provide any information about whether a reference is being read or written to (see below for the output) so the returned `DocumentHightlight`s do not have the `kind` property filled in.

```JavaScript
[
  {
    "start": {
      "row": 2,
      "column": 4
    },
    "end": {
      "row": 2,
      "column": 10
    }
  },
  {
    "start": {
      "row": 3,
      "column": 0
    },
    "end": {
      "row": 3,
      "column": 6
    }
  }
]
```