### PR TITLE
Update README.md to mention support for textDocument/documentHighlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It also requires [any supported operating system platform for Flow](https://gith
 
 - IntelliSense/code completion (`textDocument/completion`)
 - go to definition (`textDocument/definition`)
+- document highlighting (`textDocument/documentHighlight`)
 - document symbols outline (`textDocument/documentSymbol`)
 - hovers (`textDocument/hover`)
 


### PR DESCRIPTION
`textDocument/documentHighlight` support was added by #73 and should be mentioned in the README.md file.