### PR TITLE
normalize lsp line number, fix definition info for namespaced imports

### DIFF
--- a/packages/flow-language-server/src/utils/util.js
+++ b/packages/flow-language-server/src/utils/util.js
@@ -92,7 +92,7 @@ export function lspPositionToAtomPoint(lspPosition: IPosition): atom$Point {
 
 export function atomPointToLSPPosition(atomPoint: atom$PointObject): IPosition {
   return {
-    line: atomPoint.row,
+    line: atomPoint.row < 0 ? 0 : atomPoint.row,
     character: atomPoint.column,
   };
 }


### PR DESCRIPTION
This fixes a bug that `vscode` refuses to go to definition of a namespaced import such as [this](https://github.com/facebook/flow/blob/90af4eecc624422cc03201ff90cb62a86522c24e/tests/get-def/imports.js#L10) based on information received from LSP server.

The problem is that LSP server returns negative line number. This comes up because:
1. `flow` returns a line number 0 from `get-def` in this case
2. `nuclide`'s flow service (used by LSP server) decrements line number on [this line](https://github.com/flowtype/flow-language-server/blob/9b252d922b62c2097ce8ec78d818687ba3219f32/packages/flow-language-server/src/pkg/nuclide-flow-rpc/lib/FlowSingleProjectLanguageService.js#L146)

I am aware this could be treated as an upstream issue, but:
1. `flow` has a [test for this](https://github.com/facebook/flow/blob/90af4eecc624422cc03201ff90cb62a86522c24e/tests/get-def/get-def.exp#L14), so it seems that this behavior is by design.
2. it seems that `atom/nuclide` does not mind negative line number, so the `nuclide` team might not be interested in this.

Based on this, I concluded this is the best place to fix this.